### PR TITLE
Load .env configuration before starting runtime

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -2,9 +2,12 @@ package main
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"os"
+
+	"github.com/joho/godotenv"
 
 	"github.com/asynkron/goagent/internal/core/runtime"
 )
@@ -20,6 +23,15 @@ func main() {
 		autoMessage        = flag.String("auto-message", "", "auto-response sent when no human is available")
 	)
 	flag.Parse()
+
+	if err := godotenv.Load(); err != nil {
+		// A missing .env file is fine, but other errors should be surfaced to help with debugging.
+		var pathErr *os.PathError
+		if !errors.As(err, &pathErr) {
+			fmt.Fprintf(os.Stderr, "failed to load .env: %v\n", err)
+			os.Exit(1)
+		}
+	}
 
 	apiKey := os.Getenv("OPENAI_API_KEY")
 	if apiKey == "" {

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/asynkron/goagent
 
 go 1.22
+
+require github.com/joho/godotenv v1.5.1

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
+github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=

--- a/internal/core/runtime/command_executor.go
+++ b/internal/core/runtime/command_executor.go
@@ -79,7 +79,8 @@ func (e *CommandExecutor) Execute(ctx context.Context, step PlanStep) (PlanObser
 		Plan:      nil,
 	}
 
-	if exitErr := (&exec.ExitError{}); errors.As(runErr, &exitErr) {
+	var exitErr *exec.ExitError
+	if errors.As(runErr, &exitErr) {
 		code := exitErr.ExitCode()
 		observation.ExitCode = &code
 	} else if runErr == nil {
@@ -87,7 +88,7 @@ func (e *CommandExecutor) Execute(ctx context.Context, step PlanStep) (PlanObser
 		observation.ExitCode = &zero
 	}
 
-	if runErr != nil && !errors.As(runErr, &exec.ExitError{}) {
+	if runErr != nil && exitErr == nil {
 		observation.Details = runErr.Error()
 	}
 


### PR DESCRIPTION
## Summary
- load variables from a `.env` file before starting the runtime, surfacing unexpected load errors
- add the `github.com/joho/godotenv` dependency to support dotenv loading
- fix command executor exit error handling so the package compiles on recent Go versions

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68fbd78fe77c83288ae45ba2b55a172f