### PR TITLE
Integrate OpenAI plan generation

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -14,8 +14,16 @@ import (
 
 // main bootstraps the Go translation of the GoAgent runtime.
 func main() {
+	defaultModel := os.Getenv("OPENAI_MODEL")
+	if defaultModel == "" {
+		defaultModel = "gpt-4.1"
+	}
+
+	defaultReasoning := os.Getenv("OPENAI_REASONING_EFFORT")
+
 	var (
-		model              = flag.String("model", "gpt-4.1", "OpenAI model identifier to use for responses")
+		model              = flag.String("model", defaultModel, "OpenAI model identifier to use for responses")
+		reasoningEffort    = flag.String("reasoning-effort", defaultReasoning, "Reasoning effort hint forwarded to OpenAI (low, medium, high)")
 		autoApprove        = flag.Bool("auto-approve", false, "execute plan steps without manual confirmation")
 		noHuman            = flag.Bool("no-human", false, "operate without waiting for user input between passes")
 		promptAugmentation = flag.String("augment", "", "additional system prompt instructions appended after the default prompt")
@@ -42,6 +50,7 @@ func main() {
 	options := runtime.RuntimeOptions{
 		APIKey:              apiKey,
 		Model:               *model,
+		ReasoningEffort:     *reasoningEffort,
 		AutoApprove:         *autoApprove,
 		NoHuman:             *noHuman,
 		SystemPromptAugment: *promptAugmentation,

--- a/internal/core/runtime/options.go
+++ b/internal/core/runtime/options.go
@@ -13,6 +13,7 @@ import (
 type RuntimeOptions struct {
 	APIKey              string
 	Model               string
+	ReasoningEffort     string
 	AutoApprove         bool
 	NoHuman             bool
 	SystemPromptAugment string


### PR DESCRIPTION
## Summary
- read model and reasoning defaults from OPENAI_MODEL and OPENAI_REASONING_EFFORT environment variables
- extend the OpenAI client to forward reasoning settings while forcing the tool schema
- wire the runtime prompt handler to call OpenAI, persist chat history, and emit plan metadata events

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68fbd938f9d883288f9f2bb47f15231a