### PR TITLE
Implement command execution and surface runtime outputs

### DIFF
--- a/internal/core/runtime/types.go
+++ b/internal/core/runtime/types.go
@@ -80,6 +80,7 @@ type PlanStep struct {
 	WaitingForID []string         `json:"waitingForId"`
 	Command      CommandDraft     `json:"command"`
 	Observation  *PlanObservation `json:"observation,omitempty"`
+	Executing    bool             `json:"-"`
 }
 
 // PlanResponse captures the structured assistant output.


### PR DESCRIPTION
## Summary
- integrate the command executor into the runtime to run pending plan steps, update plan history, and emit detailed events
- track running plan steps inside the plan manager and plan step schema to prevent duplicate execution
- update the CLI to consume the runtime output channel directly and print event metadata for users

## Testing
- go build ./...


------
https://chatgpt.com/codex/tasks/task_e_68fbdcf475a08328b02138477b6eebc8