### PR TITLE
Stop persisting plan responses as tool messages

### DIFF
--- a/internal/core/runtime/runtime.go
+++ b/internal/core/runtime/runtime.go
@@ -3,7 +3,6 @@ package runtime
 import (
 	"bufio"
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
@@ -346,24 +345,6 @@ func (r *Runtime) recordPlanResponse(plan *PlanResponse, toolCall ToolCall) int 
 		ToolCalls: []ToolCall{toolCall},
 	}
 	r.appendHistory(assistantMessage)
-
-	planBytes, err := json.Marshal(plan)
-	if err != nil {
-		r.emit(RuntimeEvent{
-			Type:    EventTypeError,
-			Message: fmt.Sprintf("Failed to encode plan: %v", err),
-			Level:   StatusLevelError,
-		})
-	} else {
-		toolMessage := ChatMessage{
-			Role:       RoleTool,
-			Content:    string(planBytes),
-			ToolCallID: toolCall.ID,
-			Name:       toolCall.Name,
-			Timestamp:  time.Now(),
-		}
-		r.appendHistory(toolMessage)
-	}
 
 	r.plan.Replace(plan.Plan)
 


### PR DESCRIPTION
## Summary
- stop recording plan responses as tool chat messages so runtime events and PlanManager surface the plan
- keep plan metadata flow unchanged when replacing the active plan

## Testing
- go test ./...
- go run cmd/main.go *(fails: OPENAI_API_KEY must be set)*

------
https://chatgpt.com/codex/tasks/task_e_68fc9093f6d883289b546b891cbae083