### PR TITLE
Add runtime validation for invalid plan responses

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,12 @@ module github.com/asynkron/goagent
 
 go 1.22
 
-require github.com/joho/godotenv v1.5.1
+require (
+	github.com/joho/godotenv v1.5.1
+	github.com/xeipuuv/gojsonschema v1.2.0
+)
+
+require (
+	github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f // indirect
+	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,15 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
 github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
+github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f h1:J9EGpcZtP0E/raorCMxlFGSTBrsSlaDGf3jU/qvAE2c=
+github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
+github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 h1:EzJWgHovont7NscjpAxXsDA8S8BMYve8Y5+7cuRE7R0=
+github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415/go.mod h1:GwrjFmJcFw6At/Gs6z4yjiIwzuJ1/+UwLxMQDVQXShQ=
+github.com/xeipuuv/gojsonschema v1.2.0 h1:LhYJRs+L4fBtjZUfuSZIKGeVu0QRy8e5Xi7D17UxZ74=
+github.com/xeipuuv/gojsonschema v1.2.0/go.mod h1:anYRn/JVcOK2ZgGU+IjEV4nwlhoK5sQluxsYJ78Id3Y=

--- a/internal/core/runtime/runtime.go
+++ b/internal/core/runtime/runtime.go
@@ -3,11 +3,15 @@ package runtime
 import (
 	"bufio"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/asynkron/goagent/internal/core/schema"
+	"github.com/xeipuuv/gojsonschema"
 )
 
 // Runtime is the Go counterpart to the TypeScript AgentRuntime. It exposes two
@@ -32,6 +36,12 @@ type Runtime struct {
 	historyMu sync.RWMutex
 	history   []ChatMessage
 }
+
+var (
+	planSchemaLoader     gojsonschema.JSONLoader
+	planSchemaLoaderErr  error
+	planSchemaLoaderOnce sync.Once
+)
 
 // NewRuntime configures a new runtime with the provided options.
 func NewRuntime(options RuntimeOptions) (*Runtime, error) {
@@ -322,20 +332,209 @@ func (r *Runtime) planExecutionLoop(ctx context.Context, initialPlan *PlanRespon
 // to the OpenAI client, and emits a status update so hosts can surface that a
 // response was received.
 func (r *Runtime) requestPlan(ctx context.Context) (*PlanResponse, ToolCall, error) {
-	history := r.historySnapshot()
+	for {
+		history := r.historySnapshot()
 
-	plan, toolCall, err := r.client.RequestPlan(ctx, history)
+		_, toolCall, err := r.client.RequestPlan(ctx, history)
+		if err != nil {
+			return nil, ToolCall{}, err
+		}
+
+		plan, retry, validationErr := r.validatePlanToolCall(toolCall)
+		if validationErr != nil {
+			return nil, ToolCall{}, validationErr
+		}
+		if retry {
+			continue
+		}
+
+		r.emit(RuntimeEvent{
+			Type:    EventTypeStatus,
+			Message: "Assistant response received.",
+			Level:   StatusLevelInfo,
+		})
+
+		return plan, toolCall, nil
+	}
+}
+
+const validationDetailLimit = 512
+
+type schemaValidationError struct {
+	issues []string
+}
+
+func (e schemaValidationError) Error() string {
+	if len(e.issues) == 0 {
+		return "plan response failed schema validation"
+	}
+	return strings.Join(e.issues, "; ")
+}
+
+// validatePlanToolCall ensures the assistant response is valid JSON and
+// satisfies the plan schema before we hydrate a PlanResponse structure.
+// Returning retry=true signals that the helper produced feedback for the
+// assistant and the runtime should request a new plan immediately.
+func (r *Runtime) validatePlanToolCall(toolCall ToolCall) (*PlanResponse, bool, error) {
+	trimmedArgs := strings.TrimSpace(toolCall.Arguments)
+	if trimmedArgs == "" {
+		payload := PlanObservationPayload{
+			JSONParseError:          true,
+			ResponseValidationError: true,
+			Summary:                 "Assistant called the tool without providing arguments.",
+			Details:                 "tool arguments were empty",
+		}
+		r.handlePlanValidationFailure(toolCall, payload, r.buildValidationAutoPrompt(payload))
+		return nil, true, nil
+	}
+
+	var plan PlanResponse
+	if err := json.Unmarshal([]byte(toolCall.Arguments), &plan); err != nil {
+		payload := PlanObservationPayload{
+			JSONParseError:          true,
+			ResponseValidationError: true,
+			Summary:                 "Tool call arguments were not valid JSON.",
+			Details:                 err.Error(),
+		}
+		r.handlePlanValidationFailure(toolCall, payload, r.buildValidationAutoPrompt(payload))
+		return nil, true, nil
+	}
+
+	if err := validatePlanAgainstSchema(toolCall.Arguments); err != nil {
+		var schemaErr schemaValidationError
+		if errors.As(err, &schemaErr) {
+			payload := PlanObservationPayload{
+				SchemaValidationError:   true,
+				ResponseValidationError: true,
+				Summary:                 "Tool call arguments failed schema validation.",
+				Details:                 schemaErr.Error(),
+			}
+			r.handlePlanValidationFailure(toolCall, payload, r.buildValidationAutoPrompt(payload))
+			return nil, true, nil
+		}
+		return nil, false, err
+	}
+
+	return &plan, false, nil
+}
+
+func validatePlanAgainstSchema(raw string) error {
+	loader, err := loadPlanSchema()
 	if err != nil {
-		return nil, ToolCall{}, err
+		return fmt.Errorf("runtime: load plan schema: %w", err)
+	}
+
+	result, err := gojsonschema.Validate(loader, gojsonschema.NewStringLoader(raw))
+	if err != nil {
+		return fmt.Errorf("runtime: schema validation error: %w", err)
+	}
+	if result.Valid() {
+		return nil
+	}
+
+	issues := make([]string, 0, len(result.Errors()))
+	for _, desc := range result.Errors() {
+		issues = append(issues, desc.String())
+	}
+	return schemaValidationError{issues: issues}
+}
+
+func loadPlanSchema() (gojsonschema.JSONLoader, error) {
+	planSchemaLoaderOnce.Do(func() {
+		schemaMap, err := schema.PlanResponseSchema()
+		if err != nil {
+			planSchemaLoaderErr = err
+			return
+		}
+		planSchemaLoader = gojsonschema.NewGoLoader(schemaMap)
+	})
+	if planSchemaLoaderErr != nil {
+		return nil, planSchemaLoaderErr
+	}
+	return planSchemaLoader, nil
+}
+
+func (r *Runtime) handlePlanValidationFailure(toolCall ToolCall, payload PlanObservationPayload, autoPrompt string) {
+	payload.Details = strings.TrimSpace(payload.Details)
+
+	metadata := map[string]any{
+		"details": payload.Details,
+	}
+	if toolCall.ID != "" {
+		metadata["tool_call_id"] = toolCall.ID
+	}
+	if toolCall.Name != "" {
+		metadata["tool_name"] = toolCall.Name
 	}
 
 	r.emit(RuntimeEvent{
-		Type:    EventTypeStatus,
-		Message: "Assistant response received.",
-		Level:   StatusLevelInfo,
+		Type:     EventTypeStatus,
+		Message:  payload.Summary,
+		Level:    StatusLevelWarn,
+		Metadata: metadata,
 	})
 
-	return plan, toolCall, nil
+	r.appendHistory(ChatMessage{
+		Role:      RoleAssistant,
+		Timestamp: time.Now(),
+		ToolCalls: []ToolCall{toolCall},
+	})
+
+	if toolCall.ID != "" {
+		if toolMessage, err := BuildToolMessage(payload); err != nil {
+			r.emit(RuntimeEvent{
+				Type:    EventTypeError,
+				Message: fmt.Sprintf("Failed to encode validation feedback: %v", err),
+				Level:   StatusLevelError,
+			})
+		} else {
+			r.appendHistory(ChatMessage{
+				Role:       RoleTool,
+				Content:    toolMessage,
+				ToolCallID: toolCall.ID,
+				Name:       toolCall.Name,
+				Timestamp:  time.Now(),
+			})
+		}
+	}
+
+	if strings.TrimSpace(autoPrompt) != "" {
+		r.appendHistory(ChatMessage{
+			Role:      RoleUser,
+			Content:   autoPrompt,
+			Timestamp: time.Now(),
+		})
+	}
+}
+
+func (r *Runtime) buildValidationAutoPrompt(payload PlanObservationPayload) string {
+	summary := strings.TrimSpace(payload.Summary)
+	if summary == "" {
+		summary = "The previous tool call response could not be processed."
+	}
+	details := truncateForPrompt(strings.TrimSpace(payload.Details), validationDetailLimit)
+
+	builder := strings.Builder{}
+	builder.WriteString(summary)
+	if details != "" {
+		builder.WriteString(" Details: ")
+		builder.WriteString(details)
+	}
+	builder.WriteString(" Please call ")
+	builder.WriteString(schema.ToolName)
+	builder.WriteString(" again with JSON that strictly matches the provided schema.")
+	return builder.String()
+}
+
+func truncateForPrompt(value string, limit int) string {
+	if limit <= 0 {
+		return value
+	}
+	runes := []rune(value)
+	if len(runes) <= limit {
+		return value
+	}
+	return string(runes[:limit]) + "…"
 }
 
 func (r *Runtime) recordPlanResponse(plan *PlanResponse, toolCall ToolCall) int {


### PR DESCRIPTION
## Summary
- return raw OpenAI tool call payloads so validation can happen inside the runtime
- validate tool responses against JSON parsing and the plan schema, surfacing structured feedback and auto-prompts when corrections are needed
- add gojsonschema dependency to support runtime schema validation

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68fc9fa7cf6c8328a9bc54f71e80bc33