### PR TITLE
Handle plans that request human input

### DIFF
--- a/internal/core/runtime/types.go
+++ b/internal/core/runtime/types.go
@@ -85,6 +85,7 @@ type PlanStep struct {
 
 // PlanResponse captures the structured assistant output.
 type PlanResponse struct {
-	Message string     `json:"message"`
-	Plan    []PlanStep `json:"plan"`
+	Message           string     `json:"message"`
+	Plan              []PlanStep `json:"plan"`
+	RequireHumanInput bool       `json:"requireHumanInput"`
 }

--- a/internal/core/schema/schema.go
+++ b/internal/core/schema/schema.go
@@ -111,6 +111,11 @@ const planResponseSchemaJSON = `{
           }
         }
       }
+    },
+    "requireHumanInput": {
+      "type": "boolean",
+      "description": "Set true when the assistant needs additional direction from the human before continuing execution.",
+      "default": false
     }
   }
 }`


### PR DESCRIPTION
## Summary
- extend the plan response schema and runtime types to include a `requireHumanInput` flag
- surface metadata about the new flag when recording plan responses
- stop the plan execution loop and prompt for input whenever the assistant asks for human intervention

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68fca3473ec48328a1a382f33e86c89c