### PR TITLE
Harden plan retries and sanitize command observations

### DIFF
--- a/internal/core/runtime/openai_client.go
+++ b/internal/core/runtime/openai_client.go
@@ -58,6 +58,14 @@ func (c *OpenAIClient) RequestPlan(ctx context.Context, history []ChatMessage) (
 			Function: functionDefinition{Name: c.tool.Name, Description: c.tool.Description, Parameters: c.tool.Parameters},
 		}},
 		ToolChoice: toolChoice{Type: "function", Function: &toolChoiceFunction{Name: c.tool.Name}},
+		ResponseFormat: responseFormat{
+			Type: "json_schema",
+			JSONSchema: jsonSchemaDefinition{
+				Name:   c.tool.Name,
+				Strict: true,
+				Schema: c.tool.Parameters,
+			},
+		},
 	}
 
 	if c.reasoning != "" {
@@ -143,11 +151,12 @@ func buildMessages(history []ChatMessage) []chatMessage {
 // OpenAI Chat Completions API payloads. They allow us to construct the request
 // without pulling in a heavy client dependency.
 type chatCompletionRequest struct {
-	Model      string              `json:"model"`
-	Messages   []chatMessage       `json:"messages"`
-	Tools      []toolSpecification `json:"tools"`
-	ToolChoice toolChoice          `json:"tool_choice"`
-	Reasoning  *reasoningOptions   `json:"reasoning,omitempty"`
+	Model          string              `json:"model"`
+	Messages       []chatMessage       `json:"messages"`
+	Tools          []toolSpecification `json:"tools"`
+	ToolChoice     toolChoice          `json:"tool_choice"`
+	Reasoning      *reasoningOptions   `json:"reasoning,omitempty"`
+	ResponseFormat responseFormat      `json:"response_format"`
 }
 
 type reasoningOptions struct {
@@ -191,6 +200,17 @@ type toolChoice struct {
 
 type toolChoiceFunction struct {
 	Name string `json:"name"`
+}
+
+type responseFormat struct {
+	Type       string               `json:"type"`
+	JSONSchema jsonSchemaDefinition `json:"json_schema"`
+}
+
+type jsonSchemaDefinition struct {
+	Name   string         `json:"name"`
+	Strict bool           `json:"strict"`
+	Schema map[string]any `json:"schema"`
 }
 
 type chatCompletionResponse struct {

--- a/internal/core/runtime/openai_client_test.go
+++ b/internal/core/runtime/openai_client_test.go
@@ -1,0 +1,86 @@
+package runtime
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/asynkron/goagent/internal/core/schema"
+)
+
+func TestRequestPlanIncludesResponseFormat(t *testing.T) {
+	t.Parallel()
+
+	var captured map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer r.Body.Close()
+		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
+			t.Fatalf("failed to decode request: %v", err)
+		}
+
+		response := map[string]any{
+			"choices": []any{
+				map[string]any{
+					"message": map[string]any{
+						"tool_calls": []any{
+							map[string]any{
+								"id": "call-1",
+								"function": map[string]any{
+									"name":      schema.ToolName,
+									"arguments": `{"message":"hi","plan":[],"requireHumanInput":false}`,
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(response); err != nil {
+			t.Fatalf("failed to encode response: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	client, err := NewOpenAIClient("test-key", "test-model", "")
+	if err != nil {
+		t.Fatalf("unexpected client error: %v", err)
+	}
+	client.baseURL = server.URL
+	client.httpClient = server.Client()
+
+	history := []ChatMessage{{Role: RoleUser, Content: "hi"}}
+	_, _, err = client.RequestPlan(context.Background(), history)
+	if err != nil {
+		t.Fatalf("RequestPlan returned error: %v", err)
+	}
+
+	format, ok := captured["response_format"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected response_format to be present in request")
+	}
+
+	if got := format["type"]; got != "json_schema" {
+		t.Fatalf("expected response_format.type=json_schema, got %v", got)
+	}
+
+	schemaEnvelope, ok := format["json_schema"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected response_format.json_schema to be an object")
+	}
+
+	if strict, _ := schemaEnvelope["strict"].(bool); !strict {
+		t.Fatalf("expected response_format.json_schema.strict to be true")
+	}
+
+	if name, _ := schemaEnvelope["name"].(string); name != schema.ToolName {
+		t.Fatalf("expected schema name %q, got %q", schema.ToolName, name)
+	}
+
+	if _, ok := schemaEnvelope["schema"].(map[string]any); !ok {
+		t.Fatalf("expected embedded schema to be present")
+	}
+}


### PR DESCRIPTION
## Summary
- clamp command stdout/stderr to 50 KiB, marking truncation and covering the helper with tests
- log plan validation failures with details, back off between retries, and strip command bodies from plan observations
- request OpenAI plans with strict json_schema response_format and verify the payload via tests

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68fcad4d16e4832891adedd1a17636b4