### PR TITLE
Ensure requireHumanInput flag is required in response schema

### DIFF
--- a/internal/core/schema/schema.go
+++ b/internal/core/schema/schema.go
@@ -17,7 +17,7 @@ const planResponseSchemaJSON = `{
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
   "additionalProperties": false,
-  "required": ["message", "plan"],
+  "required": ["message", "plan", "requireHumanInput"],
   "properties": {
     "message": {
       "type": "string",


### PR DESCRIPTION
## Summary
- include the requireHumanInput flag in the required fields for the runtime response schema so OpenAI accepts the tool definition

## Testing
- go test ./... *(fails: hangs while running, requires further investigation)*

------
https://chatgpt.com/codex/tasks/task_e_68fcb8c8aef88328911563c2fff59736