### PR TITLE
Add internal agent command registry and parser

### DIFF
--- a/internal/core/runtime/options.go
+++ b/internal/core/runtime/options.go
@@ -46,6 +46,10 @@ type RuntimeOptions struct {
 	// ExitCommands are matched (case insensitive) by the default input
 	// reader to trigger a graceful shutdown.
 	ExitCommands []string
+
+	// InternalCommands registers agent scoped commands that bypass the host
+	// shell. The key is the command name, matched case-insensitively.
+	InternalCommands map[string]InternalCommandHandler
 }
 
 // setDefaults applies reasonable defaults that match the behaviour of the

--- a/internal/core/runtime/runtime.go
+++ b/internal/core/runtime/runtime.go
@@ -72,6 +72,12 @@ func NewRuntime(options RuntimeOptions) (*Runtime, error) {
 		history:  initialHistory,
 	}
 
+	for name, handler := range options.InternalCommands {
+		if err := rt.executor.RegisterInternalCommand(name, handler); err != nil {
+			return nil, err
+		}
+	}
+
 	return rt, nil
 }
 


### PR DESCRIPTION
## Summary
- add an internal command registry to the command executor that handles the `agent` shell
- parse agent command arguments into named and positional values for handlers
- expose runtime option wiring for internal commands and cover the new paths with tests

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68fcbefc3618832896aec419d5bb1d8f