### PR TITLE
Load CLI defaults after reading .env

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -17,6 +17,15 @@ import (
 
 // main bootstraps the Go translation of the GoAgent runtime.
 func main() {
+	if err := godotenv.Load(); err != nil {
+		// A missing .env file is fine, but other errors should be surfaced to help with debugging.
+		var pathErr *os.PathError
+		if !errors.As(err, &pathErr) {
+			fmt.Fprintf(os.Stderr, "failed to load .env: %v\n", err)
+			os.Exit(1)
+		}
+	}
+
 	defaultModel := os.Getenv("OPENAI_MODEL")
 	if defaultModel == "" {
 		defaultModel = "gpt-5"
@@ -34,15 +43,6 @@ func main() {
 		autoMessage        = flag.String("auto-message", "", "auto-response sent when no human is available")
 	)
 	flag.Parse()
-
-	if err := godotenv.Load(); err != nil {
-		// A missing .env file is fine, but other errors should be surfaced to help with debugging.
-		var pathErr *os.PathError
-		if !errors.As(err, &pathErr) {
-			fmt.Fprintf(os.Stderr, "failed to load .env: %v\n", err)
-			os.Exit(1)
-		}
-	}
 
 	apiKey := os.Getenv("OPENAI_API_KEY")
 	if apiKey == "" {


### PR DESCRIPTION
## Summary
- load the `.env` file before evaluating CLI defaults so flag defaults pick up environment changes

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68fcc6c4085c83289b4c75ca570f6c93