### PR TITLE
Simplify RequestPlan return handling

### DIFF
--- a/internal/core/runtime/openai_client_test.go
+++ b/internal/core/runtime/openai_client_test.go
@@ -53,7 +53,7 @@ func TestRequestPlanIncludesResponseFormat(t *testing.T) {
 	client.httpClient = server.Client()
 
 	history := []ChatMessage{{Role: RoleUser, Content: "hi"}}
-	_, _, err = client.RequestPlan(context.Background(), history)
+	_, err = client.RequestPlan(context.Background(), history)
 	if err != nil {
 		t.Fatalf("RequestPlan returned error: %v", err)
 	}

--- a/internal/core/runtime/runtime.go
+++ b/internal/core/runtime/runtime.go
@@ -360,7 +360,7 @@ func (r *Runtime) requestPlan(ctx context.Context) (*PlanResponse, ToolCall, err
 	for {
 		history := r.historySnapshot()
 
-		_, toolCall, err := r.client.RequestPlan(ctx, history)
+		toolCall, err := r.client.RequestPlan(ctx, history)
 		if err != nil {
 			return nil, ToolCall{}, err
 		}


### PR DESCRIPTION
## Summary
- simplify `OpenAIClient.RequestPlan` to return only the decoded tool call payload
- update runtime planning flow and associated tests to use the streamlined signature

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68fcc7248efc83289aa1eebe8fef6f8d