### PR TITLE
Require reasoning in plan schema

### DIFF
--- a/internal/core/runtime/runtime.go
+++ b/internal/core/runtime/runtime.go
@@ -646,6 +646,9 @@ func (r *Runtime) recordPlanResponse(plan *PlanResponse, toolCall ToolCall) int 
 		"tool_name":           toolCall.Name,
 		"require_human_input": plan.RequireHumanInput,
 	}
+	if strings.TrimSpace(plan.Reasoning) != "" {
+		planMetadata["reasoning"] = plan.Reasoning
+	}
 
 	r.emit(RuntimeEvent{
 		Type:    EventTypeStatus,

--- a/internal/core/runtime/types.go
+++ b/internal/core/runtime/types.go
@@ -86,6 +86,7 @@ type PlanStep struct {
 // PlanResponse captures the structured assistant output.
 type PlanResponse struct {
 	Message           string     `json:"message"`
+	Reasoning         string     `json:"reasoning,omitempty"`
 	Plan              []PlanStep `json:"plan"`
 	RequireHumanInput bool       `json:"requireHumanInput"`
 }

--- a/internal/core/schema/schema.go
+++ b/internal/core/schema/schema.go
@@ -9,7 +9,7 @@ import (
 const ToolName = "open-agent"
 
 // toolDescription mirrors the TypeScript tool description so prompts stay aligned.
-const toolDescription = "Return the response envelope that matches the OpenAgent protocol (message, plan, and command fields)."
+const toolDescription = "Return the response envelope that matches the OpenAgent protocol (message, reasoning, plan, and command fields)."
 
 // planResponseSchemaJSON copies the Draft-07 JSON schema used by the TypeScript runtime.
 // The schema is stored as raw JSON so we can provide it to OpenAI without translation losses.
@@ -17,11 +17,16 @@ const planResponseSchemaJSON = `{
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
   "additionalProperties": false,
-  "required": ["message", "plan", "requireHumanInput"],
+  "required": ["message", "reasoning", "plan", "requireHumanInput"],
   "properties": {
     "message": {
       "type": "string",
       "description": "Markdown formatted message to the user."
+    },
+    "reasoning": {
+      "type": "string",
+      "description": "Supporting reasoning or commentary that can be used to explain the plan or message without being surfaced directly to the user.",
+      "default": ""
     },
     "plan": {
       "type": "array",

--- a/internal/core/schema/schema_test.go
+++ b/internal/core/schema/schema_test.go
@@ -1,0 +1,42 @@
+package schema
+
+import "testing"
+
+func TestPlanResponseSchemaRequiresReasoning(t *testing.T) {
+	t.Parallel()
+
+	schemaMap, err := PlanResponseSchema()
+	if err != nil {
+		t.Fatalf("PlanResponseSchema returned error: %v", err)
+	}
+
+	required, ok := schemaMap["required"].([]any)
+	if !ok {
+		t.Fatalf("expected required list to be present")
+	}
+
+	var reasoningRequired bool
+	for _, value := range required {
+		if str, _ := value.(string); str == "reasoning" {
+			reasoningRequired = true
+			break
+		}
+	}
+	if !reasoningRequired {
+		t.Fatalf("expected reasoning to be marked as required")
+	}
+
+	properties, ok := schemaMap["properties"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected schema properties to be present")
+	}
+
+	value, ok := properties["reasoning"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected reasoning property to be defined")
+	}
+
+	if typ, _ := value["type"].(string); typ != "string" {
+		t.Fatalf("expected reasoning to be a string, got %q", typ)
+	}
+}


### PR DESCRIPTION
## Summary
- require the reasoning field in the structured plan schema so strict tool outputs remain valid
- extend the schema unit test to confirm the reasoning property is required and remains a string

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68fccc064c94832886c5776ced890cf0