### PR TITLE
Add pass counter to plan execution loop

### DIFF
--- a/internal/core/runtime/loop.go
+++ b/internal/core/runtime/loop.go
@@ -162,6 +162,13 @@ func (r *Runtime) planExecutionLoop(ctx context.Context) {
 			return
 		}
 
+		pass := r.incrementPassCount()
+		r.emit(RuntimeEvent{
+			Type:    EventTypeStatus,
+			Message: fmt.Sprintf("Starting plan execution pass #%d.", pass),
+			Level:   StatusLevelInfo,
+		})
+
 		plan, toolCall, err := r.requestPlan(ctx)
 		if err != nil {
 			r.emit(RuntimeEvent{
@@ -294,6 +301,14 @@ func (r *Runtime) isWorking() bool {
 	r.workMu.Lock()
 	defer r.workMu.Unlock()
 	return r.working
+}
+
+// incrementPassCount increments the session pass counter and returns the latest total.
+func (r *Runtime) incrementPassCount() int {
+	r.passMu.Lock()
+	defer r.passMu.Unlock()
+	r.passCount++
+	return r.passCount
 }
 
 func (r *Runtime) consumeInput(ctx context.Context) error {

--- a/internal/core/runtime/runtime.go
+++ b/internal/core/runtime/runtime.go
@@ -30,6 +30,9 @@ type Runtime struct {
 
 	historyMu sync.RWMutex
 	history   []ChatMessage
+
+	passMu    sync.Mutex
+	passCount int
 }
 
 // NewRuntime configures a new runtime with the provided options.


### PR DESCRIPTION
## Summary
- track the number of plan execution passes within the runtime
- emit a status event that announces each pass number as the loop runs

## Testing
- go test ./... *(fails: command hung waiting for completion, aborted with Ctrl+C)*

------
https://chatgpt.com/codex/tasks/task_e_68fcff299cdc8328887210fb2a2c8951