### PR TITLE
Annotate runtime events with pass counter and agent name

### DIFF
--- a/internal/core/runtime/events.go
+++ b/internal/core/runtime/events.go
@@ -39,6 +39,8 @@ type RuntimeEvent struct {
 	Message  string         `json:"message"`
 	Level    StatusLevel    `json:"level,omitempty"`
 	Metadata map[string]any `json:"metadata,omitempty"`
+	Pass     int            `json:"pass"`
+	Agent    string         `json:"agent"`
 }
 
 // InputEventType distinguishes the different kinds of inputs that can be

--- a/internal/core/runtime/loop_test.go
+++ b/internal/core/runtime/loop_test.go
@@ -98,13 +98,14 @@ func TestPlanExecutionLoopPausesForHumanInput(t *testing.T) {
 			OutputBuffer: 16,
 			OutputWriter: io.Discard,
 		},
-		inputs:   make(chan InputEvent, 1),
-		outputs:  make(chan RuntimeEvent, 16),
-		closed:   make(chan struct{}),
-		plan:     NewPlanManager(),
-		client:   client,
-		executor: NewCommandExecutor(),
-		history:  []ChatMessage{{Role: RoleSystem, Content: "system"}},
+		inputs:    make(chan InputEvent, 1),
+		outputs:   make(chan RuntimeEvent, 16),
+		closed:    make(chan struct{}),
+		plan:      NewPlanManager(),
+		client:    client,
+		executor:  NewCommandExecutor(),
+		history:   []ChatMessage{{Role: RoleSystem, Content: "system"}},
+		agentName: "main",
 	}
 
 	ctx := context.Background()


### PR DESCRIPTION
## Summary
- add pass and agent fields to `RuntimeEvent` and populate them when emitting
- default the runtime's agent name to `main` and expose a helper to read the pass counter
- update tests to set the agent name and verify the new metadata is preserved

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68fd01e5237083288e3ad62606c4f342