### PR TITLE
Inline runtime history cloning

### DIFF
--- a/internal/core/runtime/history.go
+++ b/internal/core/runtime/history.go
@@ -20,9 +20,8 @@ func (r *Runtime) appendHistory(message ChatMessage) {
 func (r *Runtime) historySnapshot() []ChatMessage {
 	r.historyMu.RLock()
 	defer r.historyMu.RUnlock()
-	copyHistory := make([]ChatMessage, len(r.history))
-	copy(copyHistory, r.history)
-	return copyHistory
+
+	return append([]ChatMessage(nil), r.history...)
 }
 
 // planningHistorySnapshot prepares the history for a plan request. It compacts
@@ -40,9 +39,7 @@ func (r *Runtime) planningHistorySnapshot() []ChatMessage {
 		}
 	}
 
-	copyHistory := make([]ChatMessage, len(r.history))
-	copy(copyHistory, r.history)
-	return copyHistory
+	return append([]ChatMessage(nil), r.history...)
 }
 
 func (r *Runtime) writeHistoryLog(history []ChatMessage) {


### PR DESCRIPTION
## Summary
- remove the cloneHistory helper introduced previously
- inline slice cloning in historySnapshot and planningHistorySnapshot using append

## Testing
- go test ./internal/core/runtime -run History

------
https://chatgpt.com/codex/tasks/task_e_68fd30a1dc6883288c9a4d5e9eaa56bd