### PR TITLE
Add boot probe detection and integrate into CLI

### DIFF
--- a/cmd/bootstrap.go
+++ b/cmd/bootstrap.go
@@ -1,0 +1,13 @@
+package main
+
+import "github.com/asynkron/goagent/internal/bootprobe"
+
+// buildBootProbeAugmentation runs the boot probe suite for the provided context
+// and returns the structured result, the formatted summary, and the combined
+// augmentation string that should be forwarded to the runtime.
+func buildBootProbeAugmentation(ctx *bootprobe.Context, userAugment string) (bootprobe.BootProbeResult, string, string) {
+	result := bootprobe.Run(ctx)
+	summary := bootprobe.FormatSummary(result)
+	combined := bootprobe.CombineAugmentation(summary, userAugment)
+	return result, summary, combined
+}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -13,6 +13,7 @@ import (
 	"github.com/charmbracelet/glamour"
 	"github.com/joho/godotenv"
 
+	"github.com/asynkron/goagent/internal/bootprobe"
 	"github.com/asynkron/goagent/internal/core/runtime"
 )
 
@@ -47,11 +48,24 @@ func main() {
 		os.Exit(1)
 	}
 
+	cwd, err := os.Getwd()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to determine working directory: %v\n", err)
+		os.Exit(1)
+	}
+
+	probeCtx := bootprobe.NewContext(cwd)
+	probeResult, probeSummary, combinedAugment := buildBootProbeAugmentation(probeCtx, *promptAugmentation)
+	if probeResult.HasCapabilities() && probeSummary != "" {
+		fmt.Fprintln(os.Stdout, probeSummary)
+		fmt.Fprintln(os.Stdout)
+	}
+
 	options := runtime.RuntimeOptions{
 		APIKey:                  apiKey,
 		Model:                   *model,
 		ReasoningEffort:         *reasoningEffort,
-		SystemPromptAugment:     *promptAugmentation,
+		SystemPromptAugment:     combinedAugment,
 		DisableOutputForwarding: true,
 	}
 

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/asynkron/goagent/internal/bootprobe"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildBootProbeAugmentationIncludesSummary(t *testing.T) {
+	dir := t.TempDir()
+
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "package.json"), []byte("{}"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".prettierrc"), []byte("{}"), 0o644))
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "src"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "src", "main.ts"), []byte("export const value = 1;"), 0o644))
+
+	lookup := func(name string) (string, error) {
+		switch name {
+		case "node", "npm", "prettier", "npx":
+			return filepath.Join("/usr/bin", name), nil
+		default:
+			return "", exec.ErrNotFound
+		}
+	}
+
+	ctx := bootprobe.NewContextWithLookPath(dir, lookup)
+	result, summary, combined := buildBootProbeAugmentation(ctx, "user supplied guidance")
+
+	require.True(t, result.HasCapabilities())
+	require.NotEmpty(t, summary)
+	require.True(t, strings.HasPrefix(summary, "OS:"))
+	require.Contains(t, summary, "Node.js project")
+	require.Contains(t, combined, summary)
+	require.True(t, strings.HasSuffix(combined, "user supplied guidance"))
+	require.Contains(t, combined, "Node.js project")
+}

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ toolchain go1.25.1
 require (
 	github.com/charmbracelet/glamour v0.10.0
 	github.com/joho/godotenv v1.5.1
+	github.com/stretchr/testify v1.11.1
 	github.com/xeipuuv/gojsonschema v1.2.0
 )
 
@@ -20,6 +21,7 @@ require (
 	github.com/charmbracelet/x/cellbuf v0.0.13 // indirect
 	github.com/charmbracelet/x/exp/slice v0.0.0-20250327172914-2fdc97757edf // indirect
 	github.com/charmbracelet/x/term v0.2.1 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dlclark/regexp2 v1.11.0 // indirect
 	github.com/gorilla/css v1.0.1 // indirect
 	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
@@ -28,8 +30,8 @@ require (
 	github.com/microcosm-cc/bluemonday v1.0.27 // indirect
 	github.com/muesli/reflow v0.3.0 // indirect
 	github.com/muesli/termenv v0.16.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
-	github.com/stretchr/testify v1.11.1 // indirect
 	github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f // indirect
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
@@ -39,4 +41,5 @@ require (
 	golang.org/x/sys v0.32.0 // indirect
 	golang.org/x/term v0.31.0 // indirect
 	golang.org/x/text v0.24.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -84,5 +84,7 @@ golang.org/x/term v0.31.0 h1:erwDkOK1Msy6offm1mOgvspSkslFnIGsFnxOKoufg3o=
 golang.org/x/term v0.31.0/go.mod h1:R4BeIy7D95HzImkxGkTW1UQTtP54tio2RyHz7PwK0aw=
 golang.org/x/text v0.24.0 h1:dd5Bzh4yt5KYA8f9CJHCP4FB4D51c2c6JvN37xJJkJ0=
 golang.org/x/text v0.24.0/go.mod h1:L8rBsPeo2pSS+xqN0d5u2ikmjtmoJbDBT1b7nHvFCdU=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/bootprobe/context.go
+++ b/internal/bootprobe/context.go
@@ -1,0 +1,195 @@
+package bootprobe
+
+import (
+	"errors"
+	"io/fs"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// Context provides helper methods for inspecting the repository root and
+// interrogating the current execution environment. The helpers are intentionally
+// lightweight so that unit tests can supply fixture directories and a custom
+// command lookup implementation.
+type Context struct {
+	root     string
+	lookPath func(string) (string, error)
+}
+
+// NewContext constructs a Context rooted at the provided path. Commands are
+// resolved using exec.LookPath by default.
+func NewContext(root string) *Context {
+	return &Context{
+		root:     root,
+		lookPath: exec.LookPath,
+	}
+}
+
+// NewContextWithLookPath allows tests to override the command lookup
+// implementation so that probes can be exercised without relying on tools being
+// present on the host PATH.
+func NewContextWithLookPath(root string, lookPath func(string) (string, error)) *Context {
+	ctx := NewContext(root)
+	if lookPath != nil {
+		ctx.lookPath = lookPath
+	}
+	return ctx
+}
+
+// Root returns the root directory that probes should inspect.
+func (c *Context) Root() string {
+	return c.root
+}
+
+// HasFile reports whether a file exists relative to the repository root.
+func (c *Context) HasFile(relPath string) bool {
+	if relPath == "" {
+		return false
+	}
+	path := filepath.Join(c.root, relPath)
+	info, err := os.Stat(path)
+	if err != nil {
+		return false
+	}
+	return !info.IsDir()
+}
+
+// HasDir reports whether a directory exists relative to the repository root.
+func (c *Context) HasDir(relPath string) bool {
+	if relPath == "" {
+		return false
+	}
+	path := filepath.Join(c.root, relPath)
+	info, err := os.Stat(path)
+	if err != nil {
+		return false
+	}
+	return info.IsDir()
+}
+
+// HasAnyFile returns true if any of the provided relative paths exist.
+func (c *Context) HasAnyFile(relPaths ...string) bool {
+	for _, rel := range relPaths {
+		if c.HasFile(rel) {
+			return true
+		}
+	}
+	return false
+}
+
+// ReadFile loads the contents of a project file relative to the repository
+// root.
+func (c *Context) ReadFile(relPath string) ([]byte, error) {
+	if relPath == "" {
+		return nil, errors.New("path must be provided")
+	}
+	return os.ReadFile(filepath.Join(c.root, relPath))
+}
+
+// CommandExists reports whether a command is available on PATH.
+func (c *Context) CommandExists(name string) bool {
+	if name == "" {
+		return false
+	}
+	_, err := c.lookPath(name)
+	return err == nil
+}
+
+// FindFirstWithSuffix walks the repository looking for a file with any of the
+// provided suffixes and returns the first match. The suffix comparison is
+// case-insensitive and should include the dot (e.g. ".csproj").
+func (c *Context) FindFirstWithSuffix(suffixes ...string) (string, bool) {
+	if len(suffixes) == 0 {
+		return "", false
+	}
+	lowerSuffixes := make([]string, 0, len(suffixes))
+	for _, suffix := range suffixes {
+		if suffix == "" {
+			continue
+		}
+		lowerSuffixes = append(lowerSuffixes, strings.ToLower(suffix))
+	}
+	if len(lowerSuffixes) == 0 {
+		return "", false
+	}
+
+	var (
+		match    string
+		foundErr = errors.New("found")
+	)
+	err := filepath.WalkDir(c.root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return nil
+		}
+		if d.IsDir() {
+			// Skip large dependency directories that do not affect the probes.
+			name := d.Name()
+			if name == "node_modules" || name == ".git" || name == "vendor" || name == "target" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+
+		lower := strings.ToLower(filepath.Ext(path))
+		for _, suffix := range lowerSuffixes {
+			if lower == suffix {
+				match = path
+				return foundErr
+			}
+		}
+		return nil
+	})
+
+	if err != nil && !errors.Is(err, foundErr) {
+		return "", false
+	}
+	return match, match != ""
+}
+
+// FindFirstFileNamed walks the repository and returns the first file whose name
+// exactly matches one of the provided candidates.
+func (c *Context) FindFirstFileNamed(names ...string) (string, bool) {
+	if len(names) == 0 {
+		return "", false
+	}
+	normalized := make(map[string]struct{}, len(names))
+	for _, name := range names {
+		if name == "" {
+			continue
+		}
+		normalized[strings.ToLower(name)] = struct{}{}
+	}
+	if len(normalized) == 0 {
+		return "", false
+	}
+
+	var (
+		match    string
+		foundErr = errors.New("found")
+	)
+	err := filepath.WalkDir(c.root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return nil
+		}
+		if d.IsDir() {
+			name := d.Name()
+			if name == "node_modules" || name == ".git" || name == "vendor" || name == "target" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+
+		if _, ok := normalized[strings.ToLower(filepath.Base(path))]; ok {
+			match = path
+			return foundErr
+		}
+		return nil
+	})
+
+	if err != nil && !errors.Is(err, foundErr) {
+		return "", false
+	}
+	return match, match != ""
+}

--- a/internal/bootprobe/probes.go
+++ b/internal/bootprobe/probes.go
@@ -1,0 +1,673 @@
+package bootprobe
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+// BootProbeResult mirrors the structure returned by the upstream TypeScript
+// implementation and captures the detected capabilities of the current project
+// and execution environment.
+type BootProbeResult struct {
+	Node       *NodeProbeResult
+	Python     *PythonProbeResult
+	DotNet     *SimpleProbeResult
+	Go         *SimpleProbeResult
+	Rust       *RustProbeResult
+	JVM        *JVMProbeResult
+	Git        *SimpleProbeResult
+	Containers []ContainerProbeResult
+	Linters    []ToolingProbeResult
+	Formatters []ToolingProbeResult
+	OS         OSResult
+}
+
+// CommandStatus records whether a particular command is available on PATH.
+type CommandStatus struct {
+	Name      string
+	Available bool
+}
+
+// SimpleProbeResult captures a boolean detection and supporting indicators for
+// a tooling family.
+type SimpleProbeResult struct {
+	Detected   bool
+	Indicators []string
+	Commands   []CommandStatus
+}
+
+// NodeProbeResult captures information about a JavaScript/TypeScript project.
+type NodeProbeResult struct {
+	Detected        bool
+	Indicators      []string
+	Commands        []CommandStatus
+	HasTypeScript   bool
+	HasJavaScript   bool
+	PackageManagers []string
+}
+
+// PythonProbeResult captures Python specific metadata.
+type PythonProbeResult struct {
+	Detected   bool
+	Indicators []string
+	Commands   []CommandStatus
+	UsesPoetry bool
+	UsesPipenv bool
+}
+
+// RustProbeResult captures Rust specific metadata.
+type RustProbeResult struct {
+	Detected   bool
+	Indicators []string
+	Commands   []CommandStatus
+}
+
+// JVMProbeResult captures information about JVM build tooling.
+type JVMProbeResult struct {
+	Detected   bool
+	Indicators []string
+	Commands   []CommandStatus
+	BuildTools []string
+}
+
+// ContainerProbeResult describes container configuration or tooling.
+type ContainerProbeResult struct {
+	Detected   bool
+	Indicators []string
+	Commands   []CommandStatus
+	Runtime    string
+}
+
+// ToolingProbeResult captures formatter or linter tools.
+type ToolingProbeResult struct {
+	Name       string
+	Indicators []string
+	Commands   []CommandStatus
+}
+
+// OSResult summarises the host operating system and architecture.
+type OSResult struct {
+	GOOS         string
+	GOARCH       string
+	Distribution string
+}
+
+// Run executes all boot probes and returns a consolidated result structure.
+func Run(ctx *Context) BootProbeResult {
+	return BootProbeResult{
+		Node:       runNodeProbe(ctx),
+		Python:     runPythonProbe(ctx),
+		DotNet:     runDotNetProbe(ctx),
+		Go:         runGoProbe(ctx),
+		Rust:       runRustProbe(ctx),
+		JVM:        runJVMProbe(ctx),
+		Git:        runGitProbe(ctx),
+		Containers: runContainerProbes(ctx),
+		Linters:    runLintProbes(ctx),
+		Formatters: runFormatterProbes(ctx),
+		OS:         detectOS(),
+	}
+}
+
+func runNodeProbe(ctx *Context) *NodeProbeResult {
+	indicators := collectExistingFiles(ctx, []string{
+		"package.json",
+		"pnpm-workspace.yaml",
+		"yarn.lock",
+		"package-lock.json",
+		"tsconfig.json",
+		"tsconfig.base.json",
+		"jsconfig.json",
+	})
+
+	hasTSFile := false
+	hasJSFile := false
+	if _, ok := ctx.FindFirstWithSuffix(".ts", ".tsx"); ok {
+		hasTSFile = true
+	}
+	if _, ok := ctx.FindFirstWithSuffix(".js", ".jsx", ".mjs", ".cjs"); ok {
+		hasJSFile = true
+	}
+
+	commands := commandStatuses(ctx, "node", "npm", "pnpm", "yarn", "npx")
+	pkgManagers := availableCommandNames(commands, "npm", "pnpm", "yarn")
+
+	detected := len(indicators) > 0 || hasTSFile || hasJSFile
+	if !detected {
+		return nil
+	}
+
+	if hasTSFile {
+		indicators = append(indicators, "TypeScript sources")
+	}
+	if hasJSFile {
+		indicators = append(indicators, "JavaScript sources")
+	}
+
+	return &NodeProbeResult{
+		Detected:        true,
+		Indicators:      dedupeStrings(indicators),
+		Commands:        commands,
+		HasTypeScript:   hasTSFile,
+		HasJavaScript:   hasJSFile,
+		PackageManagers: pkgManagers,
+	}
+}
+
+func runPythonProbe(ctx *Context) *PythonProbeResult {
+	indicators := collectExistingFiles(ctx, []string{
+		"pyproject.toml",
+		"requirements.txt",
+		"requirements-dev.txt",
+		"Pipfile",
+		"setup.cfg",
+		"setup.py",
+		"environment.yml",
+	})
+
+	usesPoetry := ctx.HasFile("poetry.lock")
+	usesPipenv := ctx.HasAnyFile("Pipfile", "Pipfile.lock")
+	if usesPoetry {
+		indicators = append(indicators, "poetry.lock")
+	}
+	if usesPipenv {
+		indicators = append(indicators, "Pipenv files")
+	}
+
+	commands := commandStatuses(ctx, "python3", "python", "pip", "poetry", "pipenv")
+	if len(indicators) == 0 {
+		return nil
+	}
+
+	return &PythonProbeResult{
+		Detected:   true,
+		Indicators: dedupeStrings(indicators),
+		Commands:   commands,
+		UsesPoetry: usesPoetry,
+		UsesPipenv: usesPipenv,
+	}
+}
+
+func runDotNetProbe(ctx *Context) *SimpleProbeResult {
+	indicators := []string{}
+	if path, ok := ctx.FindFirstWithSuffix(".csproj", ".fsproj"); ok {
+		indicators = append(indicators, filepath.Base(path))
+	}
+	if ctx.HasAnyFile("global.json", "Directory.Build.props", "Directory.Build.targets") {
+		indicators = append(indicators, "SDK configuration")
+	}
+	commands := commandStatuses(ctx, "dotnet")
+	if len(indicators) == 0 {
+		return nil
+	}
+
+	return &SimpleProbeResult{
+		Detected:   true,
+		Indicators: dedupeStrings(indicators),
+		Commands:   commands,
+	}
+}
+
+func runGoProbe(ctx *Context) *SimpleProbeResult {
+	indicators := collectExistingFiles(ctx, []string{"go.mod", "go.sum", "go.work"})
+	commands := commandStatuses(ctx, "go")
+	if len(indicators) == 0 {
+		return nil
+	}
+	return &SimpleProbeResult{
+		Detected:   true,
+		Indicators: dedupeStrings(indicators),
+		Commands:   commands,
+	}
+}
+
+func runRustProbe(ctx *Context) *RustProbeResult {
+	indicators := collectExistingFiles(ctx, []string{"Cargo.toml", "Cargo.lock"})
+	commands := commandStatuses(ctx, "cargo", "rustc")
+	if len(indicators) == 0 {
+		return nil
+	}
+	return &RustProbeResult{
+		Detected:   true,
+		Indicators: dedupeStrings(indicators),
+		Commands:   commands,
+	}
+}
+
+func runJVMProbe(ctx *Context) *JVMProbeResult {
+	indicators := []string{}
+	buildTools := []string{}
+
+	if ctx.HasFile("pom.xml") || ctx.HasFile("pom.yaml") {
+		indicators = append(indicators, "Maven project")
+		buildTools = append(buildTools, "Maven")
+	}
+	if ctx.HasFile("build.gradle") || ctx.HasFile("build.gradle.kts") || ctx.HasFile("settings.gradle") {
+		indicators = append(indicators, "Gradle project")
+		buildTools = append(buildTools, "Gradle")
+	}
+	if ctx.HasFile("build.sbt") {
+		indicators = append(indicators, "SBT project")
+		buildTools = append(buildTools, "SBT")
+	}
+	if path, ok := ctx.FindFirstWithSuffix(".java", ".kt", ".scala"); ok {
+		indicators = append(indicators, filepath.Base(path))
+	}
+	commands := commandStatuses(ctx, "java", "javac", "mvn", "gradle", "gradlew", "sbt")
+	if len(indicators) == 0 {
+		return nil
+	}
+
+	return &JVMProbeResult{
+		Detected:   true,
+		Indicators: dedupeStrings(indicators),
+		Commands:   commands,
+		BuildTools: dedupeStrings(buildTools),
+	}
+}
+
+func runGitProbe(ctx *Context) *SimpleProbeResult {
+	indicators := []string{}
+	if ctx.HasDir(".git") {
+		indicators = append(indicators, ".git directory")
+	} else if path, ok := ctx.FindFirstFileNamed(".gitmodules"); ok {
+		indicators = append(indicators, filepath.Base(path))
+	}
+	commands := commandStatuses(ctx, "git")
+	if len(indicators) == 0 {
+		return nil
+	}
+	return &SimpleProbeResult{
+		Detected:   true,
+		Indicators: dedupeStrings(indicators),
+		Commands:   commands,
+	}
+}
+
+func runContainerProbes(ctx *Context) []ContainerProbeResult {
+	var results []ContainerProbeResult
+
+	dockerIndicators := collectExistingFiles(ctx, []string{
+		"Dockerfile",
+		"docker-compose.yml",
+		"docker-compose.yaml",
+		".dockerignore",
+	})
+	dockerCommands := commandStatuses(ctx, "docker")
+	if len(dockerIndicators) > 0 {
+		results = append(results, ContainerProbeResult{
+			Detected:   true,
+			Indicators: dedupeStrings(dockerIndicators),
+			Commands:   dockerCommands,
+			Runtime:    "Docker",
+		})
+	}
+
+	if status := commandStatuses(ctx, "podman"); len(status) > 0 && status[0].Available {
+		results = append(results, ContainerProbeResult{
+			Detected: true,
+			Commands: status,
+			Runtime:  "Podman",
+		})
+	}
+
+	if status := commandStatuses(ctx, "nerdctl"); len(status) > 0 && status[0].Available {
+		results = append(results, ContainerProbeResult{
+			Detected: true,
+			Commands: status,
+			Runtime:  "nerdctl",
+		})
+	}
+
+	return results
+}
+
+func runLintProbes(ctx *Context) []ToolingProbeResult {
+	var results []ToolingProbeResult
+
+	if indicators := collectExistingFiles(ctx, []string{
+		".eslintrc",
+		".eslintrc.json",
+		".eslintrc.js",
+		".eslintrc.cjs",
+		".eslintrc.yaml",
+		".eslintrc.yml",
+	}); len(indicators) > 0 {
+		results = append(results, ToolingProbeResult{
+			Name:       "ESLint",
+			Indicators: dedupeStrings(indicators),
+			Commands:   commandStatuses(ctx, "eslint", "npx"),
+		})
+	}
+
+	if ctx.HasFile("pyproject.toml") {
+		if content, err := ctx.ReadFile("pyproject.toml"); err == nil && bytesContainsAny(content, []string{"[tool.flake8]", "[tool.ruff]"}) {
+			results = append(results, ToolingProbeResult{
+				Name:       "Python linters",
+				Indicators: []string{"pyproject.toml"},
+				Commands:   commandStatuses(ctx, "ruff", "flake8"),
+			})
+		}
+	}
+
+	return results
+}
+
+func runFormatterProbes(ctx *Context) []ToolingProbeResult {
+	var results []ToolingProbeResult
+
+	if indicators := collectExistingFiles(ctx, []string{
+		".prettierrc",
+		".prettierrc.json",
+		".prettierrc.js",
+		".prettierrc.cjs",
+		".prettierrc.yaml",
+		".prettierrc.yml",
+		"prettier.config.js",
+		"prettier.config.cjs",
+	}); len(indicators) > 0 {
+		results = append(results, ToolingProbeResult{
+			Name:       "Prettier",
+			Indicators: dedupeStrings(indicators),
+			Commands:   commandStatuses(ctx, "prettier", "npx"),
+		})
+	}
+
+	if ctx.HasFile("pyproject.toml") {
+		if content, err := ctx.ReadFile("pyproject.toml"); err == nil && bytesContainsAny(content, []string{"[tool.black]", "[tool.ruff.format]"}) {
+			results = append(results, ToolingProbeResult{
+				Name:       "Python formatters",
+				Indicators: []string{"pyproject.toml"},
+				Commands:   commandStatuses(ctx, "black", "ruff"),
+			})
+		}
+	}
+
+	if ctx.HasFile(".clang-format") {
+		results = append(results, ToolingProbeResult{
+			Name:       "clang-format",
+			Indicators: []string{".clang-format"},
+			Commands:   commandStatuses(ctx, "clang-format"),
+		})
+	}
+
+	return results
+}
+
+func detectOS() OSResult {
+	return OSResult{
+		GOOS:         runtime.GOOS,
+		GOARCH:       runtime.GOARCH,
+		Distribution: readOSRelease(),
+	}
+}
+
+func collectExistingFiles(ctx *Context, files []string) []string {
+	var results []string
+	for _, file := range files {
+		if ctx.HasFile(file) {
+			results = append(results, file)
+		}
+	}
+	return results
+}
+
+func commandStatuses(ctx *Context, commands ...string) []CommandStatus {
+	statuses := make([]CommandStatus, 0, len(commands))
+	for _, cmd := range commands {
+		statuses = append(statuses, CommandStatus{
+			Name:      cmd,
+			Available: ctx.CommandExists(cmd),
+		})
+	}
+	return statuses
+}
+
+func availableCommandNames(commands []CommandStatus, names ...string) []string {
+	lookup := map[string]struct{}{}
+	includeAll := len(names) == 0
+	for _, name := range names {
+		lookup[name] = struct{}{}
+	}
+	var available []string
+	for _, cmd := range commands {
+		if !cmd.Available {
+			continue
+		}
+		if includeAll {
+			available = append(available, cmd.Name)
+			continue
+		}
+		if _, ok := lookup[cmd.Name]; ok {
+			available = append(available, cmd.Name)
+		}
+	}
+	return available
+}
+
+func dedupeStrings(values []string) []string {
+	seen := make(map[string]struct{}, len(values))
+	var result []string
+	for _, value := range values {
+		if value == "" {
+			continue
+		}
+		key := strings.ToLower(value)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		result = append(result, value)
+	}
+	return result
+}
+
+func readOSRelease() string {
+	candidates := []string{"/etc/os-release", "/usr/lib/os-release"}
+	for _, path := range candidates {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			continue
+		}
+		lower := strings.ToLower(string(data))
+		lines := strings.Split(lower, "\n")
+		for i, line := range lines {
+			lines[i] = strings.TrimSpace(line)
+		}
+		for idx, line := range lines {
+			if strings.HasPrefix(line, "pretty_name=") {
+				originalLines := strings.Split(string(data), "\n")
+				if idx < len(originalLines) {
+					value := strings.TrimSpace(originalLines[idx])
+					value = strings.TrimPrefix(value, "PRETTY_NAME=")
+					value = strings.Trim(value, "\"")
+					if value != "" {
+						return value
+					}
+				}
+			}
+		}
+	}
+	return ""
+}
+
+func bytesContainsAny(data []byte, needles []string) bool {
+	if len(data) == 0 {
+		return false
+	}
+	lowerData := strings.ToLower(string(data))
+	for _, needle := range needles {
+		if needle == "" {
+			continue
+		}
+		if strings.Contains(lowerData, strings.ToLower(needle)) {
+			return true
+		}
+	}
+	return false
+}
+
+// HasCapabilities reports whether any tooling was detected.
+func (r BootProbeResult) HasCapabilities() bool {
+	return r.Node != nil || r.Python != nil || r.DotNet != nil || r.Go != nil || r.Rust != nil || r.JVM != nil || r.Git != nil || len(r.Containers) > 0 || len(r.Linters) > 0 || len(r.Formatters) > 0
+}
+
+// SummaryLines returns the human readable bullet lines describing the detected
+// capabilities.
+func (r BootProbeResult) SummaryLines() []string {
+	var lines []string
+
+	if r.Node != nil {
+		lines = append(lines, formatNodeSummary(*r.Node))
+	}
+	if r.Python != nil {
+		lines = append(lines, formatSimpleSummary("Python project", r.Python.Indicators, r.Python.Commands))
+	}
+	if r.DotNet != nil {
+		lines = append(lines, formatSimpleSummary(".NET SDK", r.DotNet.Indicators, r.DotNet.Commands))
+	}
+	if r.Go != nil {
+		lines = append(lines, formatSimpleSummary("Go toolchain", r.Go.Indicators, r.Go.Commands))
+	}
+	if r.Rust != nil {
+		lines = append(lines, formatSimpleSummary("Rust toolchain", r.Rust.Indicators, r.Rust.Commands))
+	}
+	if r.JVM != nil {
+		lines = append(lines, formatJVMSummary(*r.JVM))
+	}
+	if r.Git != nil {
+		lines = append(lines, formatSimpleSummary("Git repository", r.Git.Indicators, r.Git.Commands))
+	}
+	if len(r.Containers) > 0 {
+		for _, container := range r.Containers {
+			lines = append(lines, formatContainerSummary(container))
+		}
+	}
+	if len(r.Linters) > 0 {
+		lines = append(lines, formatToolSummary("Linters", r.Linters))
+	}
+	if len(r.Formatters) > 0 {
+		lines = append(lines, formatToolSummary("Formatters", r.Formatters))
+	}
+
+	return lines
+}
+
+// FormatSummary renders a BootProbeResult into a human readable summary. The
+// OS line is always included, followed by detected capabilities rendered as
+// bullet points.
+func FormatSummary(result BootProbeResult) string {
+	osLine := FormatOSLine(result.OS)
+	lines := result.SummaryLines()
+	if len(lines) == 0 {
+		return osLine
+	}
+
+	for i, line := range lines {
+		lines[i] = "- " + line
+	}
+
+	return strings.Join(append([]string{osLine}, lines...), "\n")
+}
+
+// FormatOSLine renders a single line describing the host OS.
+func FormatOSLine(osResult OSResult) string {
+	if osResult.Distribution != "" {
+		return fmt.Sprintf("OS: %s/%s (%s)", osResult.GOOS, osResult.GOARCH, osResult.Distribution)
+	}
+	return fmt.Sprintf("OS: %s/%s", osResult.GOOS, osResult.GOARCH)
+}
+
+// CombineAugmentation prepends the boot probe summary to any user supplied
+// instructions so that both are available to the runtime.
+func CombineAugmentation(summary, user string) string {
+	summary = strings.TrimSpace(summary)
+	user = strings.TrimSpace(user)
+
+	switch {
+	case summary != "" && user != "":
+		return summary + "\n\n" + user
+	case summary != "":
+		return summary
+	case user != "":
+		return user
+	default:
+		return ""
+	}
+}
+
+func formatNodeSummary(result NodeProbeResult) string {
+	var details []string
+	if len(result.Indicators) > 0 {
+		details = append(details, strings.Join(result.Indicators, ", "))
+	}
+	if len(result.PackageManagers) > 0 {
+		details = append(details, "pkg mgrs: "+strings.Join(result.PackageManagers, ", "))
+	}
+	available := availableCommandNames(result.Commands)
+	if len(available) > 0 {
+		details = append(details, "commands: "+strings.Join(available, ", "))
+	}
+	return joinSummary("Node.js project", details)
+}
+
+func formatJVMSummary(result JVMProbeResult) string {
+	var details []string
+	if len(result.Indicators) > 0 {
+		details = append(details, strings.Join(result.Indicators, ", "))
+	}
+	if len(result.BuildTools) > 0 {
+		details = append(details, "build: "+strings.Join(result.BuildTools, ", "))
+	}
+	available := availableCommandNames(result.Commands)
+	if len(available) > 0 {
+		details = append(details, "commands: "+strings.Join(available, ", "))
+	}
+	return joinSummary("JVM tooling", details)
+}
+
+func formatContainerSummary(result ContainerProbeResult) string {
+	label := "Container tooling"
+	if result.Runtime != "" {
+		label = result.Runtime + " tooling"
+	}
+	var details []string
+	if len(result.Indicators) > 0 {
+		details = append(details, strings.Join(result.Indicators, ", "))
+	}
+	available := availableCommandNames(result.Commands)
+	if len(available) > 0 {
+		details = append(details, "commands: "+strings.Join(available, ", "))
+	}
+	return joinSummary(label, details)
+}
+
+func formatToolSummary(category string, tools []ToolingProbeResult) string {
+	names := make([]string, 0, len(tools))
+	for _, tool := range tools {
+		names = append(names, tool.Name)
+	}
+	return fmt.Sprintf("%s: %s", category, strings.Join(names, ", "))
+}
+
+func formatSimpleSummary(title string, indicators []string, commands []CommandStatus) string {
+	var details []string
+	if len(indicators) > 0 {
+		details = append(details, strings.Join(indicators, ", "))
+	}
+	available := availableCommandNames(commands)
+	if len(available) > 0 {
+		details = append(details, "commands: "+strings.Join(available, ", "))
+	}
+	return joinSummary(title, details)
+}
+
+func joinSummary(title string, details []string) string {
+	if len(details) == 0 {
+		return title
+	}
+	return fmt.Sprintf("%s (%s)", title, strings.Join(details, "; "))
+}

--- a/internal/bootprobe/probes_test.go
+++ b/internal/bootprobe/probes_test.go
@@ -1,0 +1,133 @@
+package bootprobe
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRunDetectsMultipleToolchains(t *testing.T) {
+	dir := t.TempDir()
+
+	mustWriteFile(t, dir, "package.json", "{}")
+	mustWriteFile(t, dir, "tsconfig.json", "{}")
+	mustWriteFile(t, dir, "yarn.lock", "lock")
+	mustWriteFile(t, dir, ".prettierrc", "{}")
+	mustWriteFile(t, dir, ".eslintrc.json", "{}")
+	mustWriteFile(t, dir, "requirements.txt", "requests==2.0.0")
+	mustWriteFile(t, dir, "poetry.lock", "package")
+	mustWriteFile(t, dir, "Pipfile", "[packages]")
+	mustWriteFile(t, dir, "pyproject.toml", `[tool.poetry]
+name = "demo"
+[tool.black]
+line-length = 88
+[tool.ruff]
+`)
+	mustWriteFile(t, dir, "setup.cfg", "[flake8]\nignore = E501")
+	mustWriteFile(t, dir, "go.mod", "module example.com/demo")
+	mustWriteFile(t, dir, "Cargo.toml", "[package]\nname='demo'")
+	mustWriteFile(t, dir, "Dockerfile", "FROM scratch")
+	mustWriteFile(t, dir, ".clang-format", "BasedOnStyle: LLVM")
+
+	dotnetDir := filepath.Join(dir, "dotnet")
+	require.NoError(t, os.MkdirAll(dotnetDir, 0o755))
+	mustWriteFile(t, dotnetDir, "app.csproj", "<Project />")
+
+	javaDir := filepath.Join(dir, "java")
+	require.NoError(t, os.MkdirAll(javaDir, 0o755))
+	mustWriteFile(t, javaDir, "pom.xml", "<project />")
+	mustWriteFile(t, javaDir, "Main.java", "class Main {}")
+
+	srcDir := filepath.Join(dir, "src")
+	require.NoError(t, os.MkdirAll(srcDir, 0o755))
+	mustWriteFile(t, srcDir, "main.ts", "export const demo = 1;")
+	mustWriteFile(t, srcDir, "index.js", "module.exports = {};")
+
+	require.NoError(t, os.Mkdir(filepath.Join(dir, ".git"), 0o755))
+
+	lookups := map[string]bool{
+		"node":         true,
+		"npm":          true,
+		"pnpm":         true,
+		"yarn":         true,
+		"npx":          true,
+		"python3":      true,
+		"python":       true,
+		"pip":          true,
+		"poetry":       true,
+		"pipenv":       true,
+		"dotnet":       true,
+		"go":           true,
+		"cargo":        true,
+		"rustc":        true,
+		"java":         true,
+		"javac":        true,
+		"mvn":          true,
+		"gradle":       true,
+		"gradlew":      true,
+		"sbt":          true,
+		"docker":       true,
+		"eslint":       true,
+		"prettier":     true,
+		"black":        true,
+		"ruff":         true,
+		"flake8":       true,
+		"clang-format": true,
+		"git":          true,
+	}
+
+	ctx := NewContextWithLookPath(dir, func(name string) (string, error) {
+		if lookups[name] {
+			return filepath.Join("/usr/bin", name), nil
+		}
+		return "", exec.ErrNotFound
+	})
+
+	result := Run(ctx)
+	require.NotNil(t, result.Node)
+	require.Contains(t, result.Node.Indicators, "package.json")
+	require.True(t, result.Node.HasTypeScript)
+	require.True(t, result.Node.HasJavaScript)
+	require.NotEmpty(t, result.Node.PackageManagers)
+
+	require.NotNil(t, result.Python)
+	require.Contains(t, result.Python.Indicators, "pyproject.toml")
+	require.True(t, result.Python.UsesPoetry)
+	require.True(t, result.Python.UsesPipenv)
+
+	require.NotNil(t, result.DotNet)
+	require.NotNil(t, result.Go)
+	require.NotNil(t, result.Rust)
+	require.NotNil(t, result.JVM)
+	require.NotNil(t, result.Git)
+	require.NotEmpty(t, result.Containers)
+	require.NotEmpty(t, result.Linters)
+	require.NotEmpty(t, result.Formatters)
+	require.True(t, result.HasCapabilities())
+
+	summary := FormatSummary(result)
+	require.Contains(t, summary, "Node.js project")
+	require.Contains(t, summary, "Go toolchain")
+	require.True(t, strings.HasPrefix(summary, "OS:"))
+}
+
+func TestCombineAugmentation(t *testing.T) {
+	summary := "OS: linux/amd64\n- Tooling"
+	combined := CombineAugmentation(summary, "user notes")
+	require.Equal(t, "OS: linux/amd64\n- Tooling\n\nuser notes", combined)
+
+	require.Equal(t, summary, CombineAugmentation(summary, ""))
+	require.Equal(t, "user", CombineAugmentation("", "user"))
+	require.Equal(t, "", CombineAugmentation("", ""))
+}
+
+func mustWriteFile(t *testing.T, dir, name, contents string) {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	require.NoError(t, os.WriteFile(path, []byte(contents), 0o644))
+}


### PR DESCRIPTION
## Summary
- add a boot probe package that discovers language toolchains, container tooling, and formatter/linter configuration while recording OS metadata
- implement summary formatting helpers and run the probes from the CLI so detected capabilities are logged and included in the system prompt augmentation
- add unit tests for the boot probe package and an integration test for the CLI augmentation flow

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68fd31d550d88328afbae0e588e97770