### PR TITLE
Add hands-free runtime controls

### DIFF
--- a/internal/core/runtime/options.go
+++ b/internal/core/runtime/options.go
@@ -17,6 +17,9 @@ type RuntimeOptions struct {
 	ReasoningEffort     string
 	SystemPromptAugment string
 	AmnesiaAfterPasses  int
+	HandsFree           bool
+	HandsFreeTopic      string
+	MaxPasses           int
 
 	// MaxContextTokens defines the soft cap for the conversation history. When
 	// the estimated usage exceeds CompactWhenPercent of this value, older
@@ -67,7 +70,10 @@ func (o *RuntimeOptions) setDefaults() {
 
 	if o.AmnesiaAfterPasses < 0 {
 		o.AmnesiaAfterPasses = 0
-  }
+	}
+	if o.MaxPasses < 0 {
+		o.MaxPasses = 0
+	}
 	if o.MaxContextTokens <= 0 || o.CompactWhenPercent <= 0 {
 		if budget, ok := defaultModelContextBudgets[strings.ToLower(o.Model)]; ok {
 			if o.MaxContextTokens <= 0 {
@@ -98,6 +104,9 @@ func (o *RuntimeOptions) setDefaults() {
 	}
 	if len(o.ExitCommands) == 0 {
 		o.ExitCommands = []string{"exit", "quit", "/exit", "/quit"}
+	}
+	if o.HandsFree && strings.TrimSpace(o.HandsFreeTopic) == "" {
+		o.HandsFreeTopic = "Hands-free session"
 	}
 }
 

--- a/internal/core/runtime/runtime.go
+++ b/internal/core/runtime/runtime.go
@@ -171,6 +171,12 @@ func (r *Runtime) currentPassCount() int {
 	return r.passCount
 }
 
+func (r *Runtime) resetPassCount() {
+	r.passMu.Lock()
+	r.passCount = 0
+	r.passMu.Unlock()
+}
+
 const baseSystemPrompt = `You are OpenAgent, an AI software engineer that plans and executes work.
 Always respond by calling the "open-agent" function tool with arguments that conform to the provided JSON schema.
 Explain your reasoning to the user in the "message" field and keep plans actionable, safe, and justified.


### PR DESCRIPTION
## Summary
- add hands-free configuration fields to runtime options with sensible defaults
- respect hands-free mode in the runtime loop by skipping input prompts, enforcing pass limits, and emitting final status events
- cover hands-free completion and pass limit exhaustion scenarios with new runtime tests

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68fd39087d548328b127429a56c39108