### PR TITLE
Add configurable OpenAI base URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,10 @@ Applications embedding the runtime can import `internal/core/runtime` and access
 the queues directly:
 
 ```go
-rt, _ := runtime.NewRuntime(runtime.RuntimeOptions{APIKey: "..."})
+rt, _ := runtime.NewRuntime(runtime.RuntimeOptions{
+    APIKey:     "...",
+    APIBaseURL: "https://api.openai.com/v1/chat/completions", // Optional override for self-hosted gateways.
+})
 go rt.Run(context.Background())
 
 rt.SubmitPrompt("Hello")
@@ -37,3 +40,12 @@ fmt.Println(event.Type, event.Message)
 Disable the built-in stdin/stdout bridges by setting
 `DisableInputReader` and `DisableOutputForwarding` when the host wants
 full control over queue processing.
+
+### Configuration knobs
+
+The runtime honours the following environment variables and flags:
+
+* `OPENAI_API_KEY` (required) – API key used for all OpenAI requests.
+* `OPENAI_MODEL` / `--model` – default model identifier.
+* `OPENAI_REASONING_EFFORT` / `--reasoning-effort` – optional reasoning effort hint.
+* `OPENAI_BASE_URL` / `--openai-base-url` – optional override for the Chat Completions endpoint, useful when routing traffic through a proxy or gateway.

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -34,11 +34,13 @@ func main() {
 	}
 
 	defaultReasoning := os.Getenv("OPENAI_REASONING_EFFORT")
+	defaultBaseURL := os.Getenv("OPENAI_BASE_URL")
 
 	var (
 		model              = flag.String("model", defaultModel, "OpenAI model identifier to use for responses")
 		reasoningEffort    = flag.String("reasoning-effort", defaultReasoning, "Reasoning effort hint forwarded to OpenAI (low, medium, high)")
 		promptAugmentation = flag.String("augment", "", "additional system prompt instructions appended after the default prompt")
+		baseURL            = flag.String("openai-base-url", defaultBaseURL, "override the OpenAI API base URL (optional)")
 	)
 	flag.Parse()
 
@@ -63,6 +65,7 @@ func main() {
 
 	options := runtime.RuntimeOptions{
 		APIKey:                  apiKey,
+		APIBaseURL:              strings.TrimSpace(*baseURL),
 		Model:                   *model,
 		ReasoningEffort:         *reasoningEffort,
 		SystemPromptAugment:     combinedAugment,

--- a/internal/core/runtime/loop_test.go
+++ b/internal/core/runtime/loop_test.go
@@ -87,7 +87,7 @@ func TestPlanExecutionLoopPausesForHumanInput(t *testing.T) {
 
 	transport := &stubTransport{body: body, statusCode: http.StatusOK}
 
-	client, err := NewOpenAIClient("test-key", "gpt-4o", "")
+	client, err := NewOpenAIClient("test-key", "gpt-4o", "", "")
 	if err != nil {
 		t.Fatalf("failed to create client: %v", err)
 	}
@@ -193,7 +193,7 @@ func TestPlanExecutionLoopHandsFreeCompletes(t *testing.T) {
 
 	transport := &stubTransport{body: body, statusCode: http.StatusOK}
 
-	client, err := NewOpenAIClient("test-key", "gpt-4o", "")
+	client, err := NewOpenAIClient("test-key", "gpt-4o", "", "")
 	if err != nil {
 		t.Fatalf("failed to create client: %v", err)
 	}
@@ -310,7 +310,7 @@ func TestPlanExecutionLoopHandsFreeStopsAtPassLimit(t *testing.T) {
 
 	transport := &stubTransport{body: body, statusCode: http.StatusOK}
 
-	client, err := NewOpenAIClient("test-key", "gpt-4o", "")
+	client, err := NewOpenAIClient("test-key", "gpt-4o", "", "")
 	if err != nil {
 		t.Fatalf("failed to create client: %v", err)
 	}

--- a/internal/core/runtime/openai_client.go
+++ b/internal/core/runtime/openai_client.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/asynkron/goagent/internal/core/schema"
@@ -23,13 +24,19 @@ type OpenAIClient struct {
 	baseURL         string
 }
 
+const defaultOpenAIBaseURL = "https://api.openai.com/v1/chat/completions"
+
 // NewOpenAIClient configures the client with the provided API key and model identifier.
-func NewOpenAIClient(apiKey, model, reasoningEffort string) (*OpenAIClient, error) {
+func NewOpenAIClient(apiKey, model, reasoningEffort, baseURL string) (*OpenAIClient, error) {
 	if apiKey == "" {
 		return nil, errors.New("openai: API key is required")
 	}
 	if model == "" {
 		return nil, errors.New("openai: model is required")
+	}
+	baseURL = strings.TrimSpace(baseURL)
+	if baseURL == "" {
+		baseURL = defaultOpenAIBaseURL
 	}
 	tool, err := schema.Definition()
 	if err != nil {
@@ -43,7 +50,7 @@ func NewOpenAIClient(apiKey, model, reasoningEffort string) (*OpenAIClient, erro
 			Timeout: 120 * time.Second,
 		},
 		tool:    tool,
-		baseURL: "https://api.openai.com/v1/chat/completions",
+		baseURL: baseURL,
 	}, nil
 }
 

--- a/internal/core/runtime/openai_client_test.go
+++ b/internal/core/runtime/openai_client_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 
 	"github.com/asynkron/goagent/internal/core/schema"
@@ -13,8 +14,13 @@ import (
 func TestRequestPlanIncludesResponseFormat(t *testing.T) {
 	t.Parallel()
 
-	var captured map[string]any
+	var (
+		captured    map[string]any
+		requestHost string
+	)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Record the host so the test can assert that the custom base URL is respected.
+		requestHost = r.Host
 		defer r.Body.Close()
 		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
 			t.Fatalf("failed to decode request: %v", err)
@@ -45,17 +51,24 @@ func TestRequestPlanIncludesResponseFormat(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client, err := NewOpenAIClient("test-key", "test-model", "")
+	client, err := NewOpenAIClient("test-key", "test-model", "", server.URL)
 	if err != nil {
 		t.Fatalf("unexpected client error: %v", err)
 	}
-	client.baseURL = server.URL
 	client.httpClient = server.Client()
 
 	history := []ChatMessage{{Role: RoleUser, Content: "hi"}}
 	_, err = client.RequestPlan(context.Background(), history)
 	if err != nil {
 		t.Fatalf("RequestPlan returned error: %v", err)
+	}
+
+	parsedURL, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("failed to parse server URL: %v", err)
+	}
+	if requestHost != parsedURL.Host {
+		t.Fatalf("expected request host %s to match server host %s", requestHost, parsedURL.Host)
 	}
 
 	format, ok := captured["response_format"].(map[string]any)

--- a/internal/core/runtime/options.go
+++ b/internal/core/runtime/options.go
@@ -13,6 +13,7 @@ import (
 // ergonomics like injecting alternative readers or writers during tests.
 type RuntimeOptions struct {
 	APIKey              string
+	APIBaseURL          string
 	Model               string
 	ReasoningEffort     string
 	SystemPromptAugment string
@@ -64,6 +65,7 @@ type RuntimeOptions struct {
 // setDefaults applies reasonable defaults that match the behaviour of the
 // TypeScript runtime while keeping Go specific knobs optional.
 func (o *RuntimeOptions) setDefaults() {
+	o.APIBaseURL = strings.TrimSpace(o.APIBaseURL)
 	if o.Model == "" {
 		o.Model = "gpt-4.1"
 	}

--- a/internal/core/runtime/runtime.go
+++ b/internal/core/runtime/runtime.go
@@ -46,7 +46,7 @@ func NewRuntime(options RuntimeOptions) (*Runtime, error) {
 		return nil, err
 	}
 
-	client, err := NewOpenAIClient(options.APIKey, options.Model, options.ReasoningEffort)
+	client, err := NewOpenAIClient(options.APIKey, options.Model, options.ReasoningEffort, options.APIBaseURL)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary
- allow runtime options to carry an optional OpenAI base URL and plumb it through to the HTTP client
- expose OPENAI_BASE_URL / --openai-base-url in the CLI and document the new knob
- extend client tests to verify custom hosts and adjust existing unit tests

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68fdbcc6c3f08328b80e49b98122f68d