### PR TITLE
Allow configuring history log persistence

### DIFF
--- a/internal/core/runtime/history.go
+++ b/internal/core/runtime/history.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"strings"
 )
 
 func (r *Runtime) appendHistory(message ChatMessage) {
@@ -54,7 +55,15 @@ func (r *Runtime) writeHistoryLog(history []ChatMessage) {
 		return
 	}
 
-	if err := os.WriteFile("history.json", data, 0o644); err != nil {
+	var historyPath string
+	if r.options.HistoryLogPath != nil {
+		historyPath = strings.TrimSpace(*r.options.HistoryLogPath)
+	}
+	if historyPath == "" {
+		return
+	}
+
+	if err := os.WriteFile(historyPath, data, 0o644); err != nil {
 		r.emit(RuntimeEvent{
 			Type:    EventTypeStatus,
 			Message: fmt.Sprintf("Failed to write history log: %v", err),

--- a/internal/core/runtime/history_test.go
+++ b/internal/core/runtime/history_test.go
@@ -1,0 +1,98 @@
+package runtime
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// helper to avoid repeating pointer boilerplate.
+func stringPtr(s string) *string {
+	return &s
+}
+
+func TestWriteHistoryLog_UsesDefaultPath(t *testing.T) {
+	tempDir := t.TempDir()
+
+	options := RuntimeOptions{}
+	options.setDefaults()
+	if options.HistoryLogPath == nil {
+		t.Fatalf("expected default history path to be configured")
+	}
+	if got := *options.HistoryLogPath; got != "history.json" {
+		t.Fatalf("expected default history path 'history.json', got %q", got)
+	}
+
+	historyPath := filepath.Join(tempDir, *options.HistoryLogPath)
+	options.HistoryLogPath = &historyPath
+
+	rt := &Runtime{
+		options:   options,
+		outputs:   make(chan RuntimeEvent, 1),
+		closed:    make(chan struct{}),
+		agentName: "test",
+	}
+
+	messages := []ChatMessage{{Role: RoleSystem, Content: "seed"}}
+	rt.writeHistoryLog(messages)
+
+	content, err := os.ReadFile(historyPath)
+	if err != nil {
+		t.Fatalf("failed to read history log: %v", err)
+	}
+
+	var logged []ChatMessage
+	if err := json.Unmarshal(content, &logged); err != nil {
+		t.Fatalf("failed to decode history log: %v", err)
+	}
+	if len(logged) != len(messages) || logged[0].Content != messages[0].Content {
+		t.Fatalf("unexpected history log contents: %+v", logged)
+	}
+}
+
+func TestWriteHistoryLog_DisabledSkipsWrite(t *testing.T) {
+	tempDir := t.TempDir()
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to snapshot working directory: %v", err)
+	}
+	if err := os.Chdir(tempDir); err != nil {
+		t.Fatalf("failed to enter temp directory: %v", err)
+	}
+	defer func() {
+		if chdirErr := os.Chdir(cwd); chdirErr != nil {
+			t.Errorf("failed to restore working directory: %v", chdirErr)
+		}
+	}()
+
+	options := RuntimeOptions{HistoryLogPath: stringPtr("")}
+	options.setDefaults()
+	if options.HistoryLogPath == nil {
+		t.Fatalf("expected history path pointer to remain set")
+	}
+	if got := *options.HistoryLogPath; got != "" {
+		t.Fatalf("expected history path to remain blank when disabled, got %q", got)
+	}
+
+	rt := &Runtime{
+		options:   options,
+		outputs:   make(chan RuntimeEvent, 1),
+		closed:    make(chan struct{}),
+		agentName: "test",
+	}
+
+	rt.writeHistoryLog([]ChatMessage{{Role: RoleUser, Content: "skip"}})
+
+	if _, err := os.Stat(filepath.Join(tempDir, "history.json")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected history log to be skipped, got err=%v", err)
+	}
+	entries, err := os.ReadDir(tempDir)
+	if err != nil {
+		t.Fatalf("failed to read temp directory: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("expected no files when history logging disabled, found %d", len(entries))
+	}
+}

--- a/internal/core/runtime/options.go
+++ b/internal/core/runtime/options.go
@@ -20,6 +20,11 @@ type RuntimeOptions struct {
 	HandsFree           bool
 	HandsFreeTopic      string
 	MaxPasses           int
+	// HistoryLogPath controls where the runtime persists the serialized
+	// conversation history. A nil pointer defaults to "history.json" to
+	// preserve the previous behaviour while allowing callers to override
+	// or disable the log entirely.
+	HistoryLogPath *string
 
 	// MaxContextTokens defines the soft cap for the conversation history. When
 	// the estimated usage exceeds CompactWhenPercent of this value, older
@@ -104,6 +109,10 @@ func (o *RuntimeOptions) setDefaults() {
 	}
 	if len(o.ExitCommands) == 0 {
 		o.ExitCommands = []string{"exit", "quit", "/exit", "/quit"}
+	}
+	if o.HistoryLogPath == nil {
+		defaultHistoryPath := "history.json"
+		o.HistoryLogPath = &defaultHistoryPath
 	}
 	if o.HandsFree && strings.TrimSpace(o.HandsFreeTopic) == "" {
 		o.HandsFreeTopic = "Hands-free session"


### PR DESCRIPTION
## Summary
- add a HistoryLogPath option that defaults to history.json while allowing overrides or disabling persistence
- update history logging to honor the configured path and skip disk writes when the path is blank
- add unit tests covering the default path behaviour and the disabled logging case

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68fdbcdd0a188328bd670da330168e7d