### PR TITLE
Queue hands-free topic prompt when runtime starts

### DIFF
--- a/internal/core/runtime/loop.go
+++ b/internal/core/runtime/loop.go
@@ -26,6 +26,10 @@ func (r *Runtime) Run(ctx context.Context) error {
 		}()
 	}
 
+	if r.options.HandsFree {
+		r.queueHandsFreePrompt()
+	}
+
 	if !r.options.DisableInputReader && !r.options.HandsFree {
 		wg.Add(1)
 		go func() {
@@ -53,7 +57,9 @@ func (r *Runtime) loop(ctx context.Context) error {
 		Message: "Agent runtime started",
 		Level:   StatusLevelInfo,
 	})
-	r.emitRequestInput("Enter a prompt to begin.")
+	if !r.options.HandsFree {
+		r.emitRequestInput("Enter a prompt to begin.")
+	}
 
 	for {
 		select {

--- a/internal/core/runtime/options.go
+++ b/internal/core/runtime/options.go
@@ -116,8 +116,11 @@ func (o *RuntimeOptions) setDefaults() {
 		defaultHistoryPath := "history.json"
 		o.HistoryLogPath = &defaultHistoryPath
 	}
-	if o.HandsFree && strings.TrimSpace(o.HandsFreeTopic) == "" {
-		o.HandsFreeTopic = "Hands-free session"
+	if o.HandsFree {
+		o.HandsFreeTopic = strings.TrimSpace(o.HandsFreeTopic)
+		if o.HandsFreeTopic == "" {
+			o.HandsFreeTopic = "Hands-free session"
+		}
 	}
 }
 

--- a/internal/core/runtime/options_test.go
+++ b/internal/core/runtime/options_test.go
@@ -1,0 +1,19 @@
+package runtime
+
+import "testing"
+
+func TestRuntimeOptionsSetDefaultsHandsFreeTopic(t *testing.T) {
+	t.Parallel()
+
+	opts := RuntimeOptions{HandsFree: true}
+	opts.setDefaults()
+	if opts.HandsFreeTopic != "Hands-free session" {
+		t.Fatalf("expected default hands-free topic, got %q", opts.HandsFreeTopic)
+	}
+
+	custom := RuntimeOptions{HandsFree: true, HandsFreeTopic: "  Explore logs   "}
+	custom.setDefaults()
+	if custom.HandsFreeTopic != "Explore logs" {
+		t.Fatalf("expected trimmed hands-free topic, got %q", custom.HandsFreeTopic)
+	}
+}

--- a/internal/core/runtime/runtime.go
+++ b/internal/core/runtime/runtime.go
@@ -113,6 +113,19 @@ func (r *Runtime) Shutdown(reason string) {
 	r.enqueue(InputEvent{Type: InputTypeShutdown, Reason: reason})
 }
 
+func (r *Runtime) queueHandsFreePrompt() {
+	if !r.options.HandsFree {
+		return
+	}
+
+	topic := strings.TrimSpace(r.options.HandsFreeTopic)
+	if topic == "" {
+		return
+	}
+
+	r.enqueue(InputEvent{Type: InputTypePrompt, Prompt: topic})
+}
+
 func (r *Runtime) enqueue(evt InputEvent) {
 	select {
 	case <-r.closed:


### PR DESCRIPTION
## Summary
- enqueue the configured hands-free topic as an initial prompt and suppress the interactive prompt request when hands-free mode is enabled
- trim hands-free topics during option setup and add unit tests covering the new startup behavior

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68fdbf3612348328902f57a255e2fae5