### PR TITLE
Document apply_patch internal command in system prompt

### DIFF
--- a/internal/core/runtime/runtime.go
+++ b/internal/core/runtime/runtime.go
@@ -244,7 +244,7 @@ apply_patch [--respect-whitespace|--ignore-whitespace]
 - The first line is the command line. You may append flags such as '--respect-whitespace' (defaults to ignoring whitespace).
 - After the command line, include a newline and wrap the patch body between '*** Begin Patch' and '*** End Patch'.
 - Start each file block with either '*** Update File: <path>' for existing files or '*** Add File: <path>' for new files. Paths are resolved relative to the step's 'cwd'.
-- Within each file block, include one or more hunks beginning with an `@@` header followed by diff lines that start with space, `+`, or `-`.
+- Within each file block, include one or more hunks beginning with an '@@' header followed by diff lines that start with space, '+', or '-'.
 
 ## execution environment and sandbox
 You are not in a sandbox, you have full access to run any command.


### PR DESCRIPTION
## Summary
- extend the default system prompt to document the apply_patch internal command and how to format its payload

## Testing
- go test ./... *(interrupted: command appeared to hang, so it was stopped with Ctrl+C)*

------
https://chatgpt.com/codex/tasks/task_e_68fdf8e602b48328b45dde581fb04082