### PR TITLE
Extract patch engine into reusable package

### DIFF
--- a/internal/core/runtime/internal_command_apply_patch.go
+++ b/internal/core/runtime/internal_command_apply_patch.go
@@ -4,88 +4,16 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/fs"
 	"os"
 	"path/filepath"
 	"sort"
 	"strings"
 	"unicode"
+
+	"github.com/asynkron/goagent/pkg/patch"
 )
 
-const (
-	applyPatchCommandName = "apply_patch"
-)
-
-type applyPatchOptions struct {
-	ignoreWhitespace bool
-	workingDir       string
-}
-
-type patchOperation struct {
-	opType   string
-	path     string
-	movePath string
-	hunks    []patchHunk
-}
-
-type patchHunk struct {
-	before        []string
-	after         []string
-	header        string
-	lines         []string
-	rawPatchLines []string
-	atEOF         bool
-}
-
-type hunkStatus struct {
-	Number int    `json:"number"`
-	Status string `json:"status"`
-}
-
-type failedHunk struct {
-	Number        int      `json:"number"`
-	RawPatchLines []string `json:"rawPatchLines"`
-}
-
-type patchError struct {
-	Message         string
-	Code            string
-	RelativePath    string
-	OriginalContent string
-	HunkStatuses    []hunkStatus
-	FailedHunk      *failedHunk
-}
-
-func (e *patchError) Error() string {
-	if e == nil {
-		return ""
-	}
-	if e.Message != "" {
-		return e.Message
-	}
-	return "patch error"
-}
-
-type fileState struct {
-	path                    string
-	relativePath            string
-	lines                   []string
-	normalizedLines         []string
-	originalContent         string
-	originalEndsWithNewline *bool
-	originalMode            fs.FileMode
-	touched                 bool
-	cursor                  int
-	hunkStatuses            []hunkStatus
-	isNew                   bool
-	movePath                string
-	options                 applyPatchOptions
-}
-
-type fileResult struct {
-	status string
-	path   string
-}
+const applyPatchCommandName = "apply_patch"
 
 func newApplyPatchCommand() InternalCommandHandler {
 	return func(ctx context.Context, req InternalCommandRequest) (PlanObservationPayload, error) {
@@ -106,7 +34,7 @@ func newApplyPatchCommand() InternalCommandHandler {
 			return failApplyPatch(&payload, err.Error()), err
 		}
 
-		operations, err := parsePatch(patchInput)
+		operations, err := patch.Parse(patchInput)
 		if err != nil {
 			message := fmt.Sprintf("apply_patch: %v", err)
 			return failApplyPatch(&payload, message), fmt.Errorf("apply_patch: %w", err)
@@ -117,10 +45,14 @@ func newApplyPatchCommand() InternalCommandHandler {
 			return failApplyPatch(&payload, err.Error()), err
 		}
 
-		results, applyErr := applyPatchOperations(ctx, operations, opts)
+		results, applyErr := patch.ApplyFilesystem(ctx, operations, opts)
 		if applyErr != nil {
-			formatted := formatPatchError(applyErr)
-			return failApplyPatch(&payload, formatted), applyErr
+			var perr *patch.Error
+			if errors.As(applyErr, &perr) {
+				formatted := patch.FormatError(perr)
+				return failApplyPatch(&payload, formatted), perr
+			}
+			return failApplyPatch(&payload, applyErr.Error()), applyErr
 		}
 
 		if len(results) == 0 {
@@ -131,15 +63,15 @@ func newApplyPatchCommand() InternalCommandHandler {
 		}
 
 		sort.Slice(results, func(i, j int) bool {
-			return results[i].path < results[j].path
+			return results[i].Path < results[j].Path
 		})
 
 		builder := strings.Builder{}
 		builder.WriteString("Success. Updated the following files:\n")
 		for _, entry := range results {
-			builder.WriteString(entry.status)
+			builder.WriteString(entry.Status)
 			builder.WriteString(" ")
-			builder.WriteString(entry.path)
+			builder.WriteString(entry.Path)
 			builder.WriteString("\n")
 		}
 
@@ -173,13 +105,13 @@ func splitCommandAndPatch(raw string) (commandLine, patch string) {
 	return line, rest
 }
 
-func parseApplyPatchOptions(commandLine, cwd string) (applyPatchOptions, error) {
+func parseApplyPatchOptions(commandLine, cwd string) (patch.FilesystemOptions, error) {
 	tokens, err := tokenizeInternalCommand(commandLine)
 	if err != nil {
-		return applyPatchOptions{}, fmt.Errorf("failed to parse command line: %w", err)
+		return patch.FilesystemOptions{}, fmt.Errorf("failed to parse command line: %w", err)
 	}
 	if len(tokens) == 0 {
-		return applyPatchOptions{}, errors.New("apply_patch: missing command name")
+		return patch.FilesystemOptions{}, errors.New("apply_patch: missing command name")
 	}
 
 	workingDir := strings.TrimSpace(cwd)
@@ -187,14 +119,14 @@ func parseApplyPatchOptions(commandLine, cwd string) (applyPatchOptions, error) 
 		if wd, getErr := os.Getwd(); getErr == nil {
 			workingDir = wd
 		} else {
-			return applyPatchOptions{}, fmt.Errorf("failed to determine working directory: %w", getErr)
+			return patch.FilesystemOptions{}, fmt.Errorf("failed to determine working directory: %w", getErr)
 		}
 	}
 	if abs, err := filepath.Abs(workingDir); err == nil {
 		workingDir = abs
 	}
 
-	opts := applyPatchOptions{ignoreWhitespace: true, workingDir: workingDir}
+	opts := patch.FilesystemOptions{Options: patch.Options{IgnoreWhitespace: true}, WorkingDir: workingDir}
 	for _, token := range tokens[1:] {
 		if eq := strings.IndexRune(token, '='); eq != -1 {
 			key := strings.TrimSpace(token[:eq])
@@ -202,13 +134,13 @@ func parseApplyPatchOptions(commandLine, cwd string) (applyPatchOptions, error) 
 			switch strings.ToLower(key) {
 			case "ignore_whitespace", "ignore-whitespace":
 				if strings.EqualFold(value, "false") {
-					opts.ignoreWhitespace = false
+					opts.IgnoreWhitespace = false
 				} else if strings.EqualFold(value, "true") {
-					opts.ignoreWhitespace = true
+					opts.IgnoreWhitespace = true
 				}
 			case "respect_whitespace", "respect-whitespace":
 				if strings.EqualFold(value, "true") {
-					opts.ignoreWhitespace = false
+					opts.IgnoreWhitespace = false
 				}
 			}
 			continue
@@ -216,697 +148,19 @@ func parseApplyPatchOptions(commandLine, cwd string) (applyPatchOptions, error) 
 
 		switch token {
 		case "--ignore-whitespace", "-w":
-			opts.ignoreWhitespace = true
-		case "--respect-whitespace", "--no-ignore-whitespace":
-			opts.ignoreWhitespace = false
-		case "-W":
-			opts.ignoreWhitespace = false
+			opts.IgnoreWhitespace = true
+		case "--respect-whitespace", "--no-ignore-whitespace", "-W":
+			opts.IgnoreWhitespace = false
 		default:
 			lower := strings.ToLower(token)
 			if lower == "--respect-whitespace" || lower == "--no-ignore-whitespace" {
-				opts.ignoreWhitespace = false
+				opts.IgnoreWhitespace = false
 			} else if lower == "--ignore-whitespace" {
-				opts.ignoreWhitespace = true
+				opts.IgnoreWhitespace = true
 			}
 		}
 	}
 	return opts, nil
-}
-
-func parsePatch(input string) ([]patchOperation, error) {
-	lines := splitLines(input)
-	var (
-		operations  []patchOperation
-		currentOp   *patchOperation
-		currentHunk *patchHunk
-		inside      bool
-	)
-
-	flushHunk := func() error {
-		if currentHunk == nil {
-			return nil
-		}
-		if currentOp == nil {
-			return errors.New("hunk encountered before file directive")
-		}
-		parsed, err := parseHunk(currentHunk.lines, currentOp.path, currentHunk.header)
-		if err != nil {
-			return err
-		}
-		currentOp.hunks = append(currentOp.hunks, parsed)
-		currentHunk = nil
-		return nil
-	}
-
-	flushOp := func() error {
-		if currentOp == nil {
-			return nil
-		}
-		if err := flushHunk(); err != nil {
-			return err
-		}
-		if len(currentOp.hunks) == 0 && !(currentOp.opType == "update" && strings.TrimSpace(currentOp.movePath) != "") {
-			return fmt.Errorf("no hunks provided for %s", currentOp.path)
-		}
-		operations = append(operations, *currentOp)
-		currentOp = nil
-		return nil
-	}
-
-	for _, rawLine := range lines {
-		line := rawLine
-		switch line {
-		case "*** Begin Patch":
-			inside = true
-			continue
-		case "*** End Patch":
-			if inside {
-				if err := flushOp(); err != nil {
-					return nil, err
-				}
-			}
-			inside = false
-			continue
-		}
-
-		if !inside {
-			continue
-		}
-
-		trimmed := strings.TrimSpace(line)
-
-		if trimmed == "*** End of File" {
-			if currentOp == nil {
-				return nil, fmt.Errorf("end-of-file marker encountered before a file directive")
-			}
-			if currentHunk == nil {
-				currentHunk = &patchHunk{}
-			}
-			currentHunk.lines = append(currentHunk.lines, line)
-			continue
-		}
-
-		if strings.HasPrefix(trimmed, "*** Move to: ") {
-			if currentOp == nil {
-				return nil, fmt.Errorf("move directive encountered before a file directive")
-			}
-			if currentOp.opType != "update" {
-				return nil, fmt.Errorf("move directive only allowed for update operations")
-			}
-			currentOp.movePath = strings.TrimSpace(strings.TrimPrefix(trimmed, "*** Move to: "))
-			continue
-		}
-
-		if strings.HasPrefix(trimmed, "*** Delete File: ") {
-			if err := flushOp(); err != nil {
-				return nil, err
-			}
-			path := strings.TrimSpace(strings.TrimPrefix(trimmed, "*** Delete File: "))
-			operations = append(operations, patchOperation{opType: "delete", path: path})
-			currentOp = nil
-			currentHunk = nil
-			continue
-		}
-
-		if strings.HasPrefix(trimmed, "*** ") {
-			if err := flushOp(); err != nil {
-				return nil, err
-			}
-			if updatePath, ok := strings.CutPrefix(trimmed, "*** Update File: "); ok {
-				path := strings.TrimSpace(updatePath)
-				currentOp = &patchOperation{opType: "update", path: path}
-				continue
-			}
-			if addPath, ok := strings.CutPrefix(trimmed, "*** Add File: "); ok {
-				path := strings.TrimSpace(addPath)
-				currentOp = &patchOperation{opType: "add", path: path}
-				continue
-			}
-			return nil, fmt.Errorf("unsupported patch directive: %s", line)
-		}
-
-		if currentOp == nil {
-			if trimmed == "" {
-				continue
-			}
-			return nil, fmt.Errorf("diff content appeared before a file directive: %q", line)
-		}
-
-		if strings.HasPrefix(line, "@@") {
-			if err := flushHunk(); err != nil {
-				return nil, err
-			}
-			currentHunk = &patchHunk{header: line}
-			continue
-		}
-
-		if currentHunk == nil {
-			currentHunk = &patchHunk{}
-		}
-		currentHunk.lines = append(currentHunk.lines, line)
-	}
-
-	if inside {
-		return nil, errors.New("missing *** End Patch terminator")
-	}
-
-	if err := flushOp(); err != nil {
-		return nil, err
-	}
-
-	return operations, nil
-}
-
-func parseHunk(lines []string, filePath, header string) (patchHunk, error) {
-	hunk := patchHunk{header: header}
-	hunk.lines = append([]string(nil), lines...)
-	for _, raw := range lines {
-		switch {
-		case strings.HasPrefix(raw, "+"):
-			hunk.after = append(hunk.after, raw[1:])
-		case strings.HasPrefix(raw, "-"):
-			hunk.before = append(hunk.before, raw[1:])
-		case strings.HasPrefix(raw, " "):
-			value := raw[1:]
-			hunk.before = append(hunk.before, value)
-			hunk.after = append(hunk.after, value)
-		case strings.TrimSpace(raw) == "*** End of File":
-			hunk.atEOF = true
-		case raw == "\\ No newline at end of file":
-			// ignore marker
-		default:
-			return patchHunk{}, fmt.Errorf("unsupported hunk line in %s: %q", filePath, raw)
-		}
-	}
-	if header != "" {
-		hunk.rawPatchLines = append(hunk.rawPatchLines, header)
-	}
-	hunk.rawPatchLines = append(hunk.rawPatchLines, lines...)
-	return hunk, nil
-}
-
-func splitLines(input string) []string {
-	normalized := strings.ReplaceAll(input, "\r\n", "\n")
-	normalized = strings.ReplaceAll(normalized, "\r", "\n")
-	return strings.Split(normalized, "\n")
-}
-
-func applyPatchOperations(ctx context.Context, operations []patchOperation, opts applyPatchOptions) ([]fileResult, *patchError) {
-	states := make(map[string]*fileState)
-	results := []fileResult{}
-
-	resolvePath := func(relativePath string) (string, string, error) {
-		rel := strings.TrimSpace(relativePath)
-		if rel == "" {
-			return "", "", fmt.Errorf("invalid patch path")
-		}
-		cleaned := filepath.Clean(rel)
-		var abs string
-		if filepath.IsAbs(cleaned) {
-			abs = filepath.Clean(cleaned)
-		} else {
-			abs = filepath.Clean(filepath.Join(opts.workingDir, cleaned))
-		}
-		return abs, cleaned, nil
-	}
-
-	ensureState := func(relativePath string, create bool) (*fileState, error) {
-		abs, rel, err := resolvePath(relativePath)
-		if err != nil {
-			return nil, err
-		}
-		if state, ok := states[abs]; ok {
-			state.options = opts
-			if opts.ignoreWhitespace {
-				state.normalizedLines = ensureNormalizedLines(state)
-			} else {
-				state.normalizedLines = nil
-			}
-			return state, nil
-		}
-
-		info, err := os.Stat(abs)
-		switch {
-		case err == nil && create:
-			if info.IsDir() {
-				return nil, fmt.Errorf("cannot add directory %s", rel)
-			}
-			state := &fileState{
-				path:                    abs,
-				relativePath:            rel,
-				lines:                   []string{},
-				normalizedLines:         nil,
-				originalContent:         "",
-				originalEndsWithNewline: nil,
-				originalMode:            info.Mode(),
-				touched:                 false,
-				cursor:                  0,
-				hunkStatuses:            nil,
-				isNew:                   true,
-				movePath:                "",
-				options:                 opts,
-			}
-			if opts.ignoreWhitespace {
-				state.normalizedLines = []string{}
-			}
-			states[abs] = state
-			return state, nil
-		case err == nil:
-			if info.IsDir() {
-				return nil, fmt.Errorf("cannot patch directory %s", rel)
-			}
-			content, readErr := os.ReadFile(abs)
-			if readErr != nil {
-				return nil, fmt.Errorf("failed to read %s: %v", rel, readErr)
-			}
-			normalized := strings.ReplaceAll(string(content), "\r\n", "\n")
-			normalized = strings.ReplaceAll(normalized, "\r", "\n")
-			lines := strings.Split(normalized, "\n")
-			ends := strings.HasSuffix(normalized, "\n")
-			state := &fileState{
-				path:                    abs,
-				relativePath:            rel,
-				lines:                   lines,
-				normalizedLines:         nil,
-				originalContent:         string(content),
-				originalEndsWithNewline: &ends,
-				originalMode:            info.Mode(),
-				touched:                 false,
-				cursor:                  0,
-				hunkStatuses:            nil,
-				isNew:                   false,
-				movePath:                "",
-				options:                 opts,
-			}
-			if opts.ignoreWhitespace {
-				state.normalizedLines = ensureNormalizedLines(state)
-			}
-			states[abs] = state
-			return state, nil
-		case errors.Is(err, fs.ErrNotExist):
-			if !create {
-				return nil, fmt.Errorf("failed to read %s: file does not exist", rel)
-			}
-			state := &fileState{
-				path:                    abs,
-				relativePath:            rel,
-				lines:                   []string{},
-				normalizedLines:         nil,
-				originalContent:         "",
-				originalEndsWithNewline: nil,
-				originalMode:            0,
-				touched:                 false,
-				cursor:                  0,
-				hunkStatuses:            nil,
-				isNew:                   true,
-				movePath:                "",
-				options:                 opts,
-			}
-			if opts.ignoreWhitespace {
-				state.normalizedLines = []string{}
-			}
-			states[abs] = state
-			return state, nil
-		default:
-			return nil, fmt.Errorf("failed to stat %s: %v", rel, err)
-		}
-	}
-
-	for _, op := range operations {
-		if ctx.Err() != nil {
-			return nil, &patchError{Message: ctx.Err().Error()}
-		}
-
-		switch op.opType {
-		case "delete":
-			abs, rel, err := resolvePath(op.path)
-			if err != nil {
-				return nil, &patchError{Message: err.Error()}
-			}
-			info, statErr := os.Stat(abs)
-			if statErr != nil || info.IsDir() {
-				return nil, &patchError{Message: fmt.Sprintf("Failed to delete file %s", rel)}
-			}
-			if err := os.Remove(abs); err != nil {
-				return nil, &patchError{Message: fmt.Sprintf("Failed to delete file %s", rel)}
-			}
-			results = append(results, fileResult{status: "D", path: rel})
-			continue
-		case "update", "add":
-			state, err := ensureState(op.path, op.opType == "add")
-			if err != nil {
-				return nil, &patchError{Message: err.Error()}
-			}
-			state.cursor = 0
-			state.hunkStatuses = nil
-			for index, hunk := range op.hunks {
-				hunkNumber := index + 1
-				if ctx.Err() != nil {
-					return nil, &patchError{Message: ctx.Err().Error()}
-				}
-				if err := applyHunk(state, hunk); err != nil {
-					return nil, enhanceHunkError(err, state, hunk, hunkNumber)
-				}
-				state.hunkStatuses = append(state.hunkStatuses, hunkStatus{Number: hunkNumber, Status: "applied"})
-				state.touched = true
-			}
-			trimmedMove := strings.TrimSpace(op.movePath)
-			if trimmedMove != "" {
-				state.movePath = trimmedMove
-				state.touched = true
-			}
-		default:
-			return nil, &patchError{Message: fmt.Sprintf("unsupported patch operation for %s: %s", op.path, op.opType)}
-		}
-	}
-
-	for _, state := range states {
-		if !state.touched {
-			continue
-		}
-		newContent := strings.Join(state.lines, "\n")
-		if state.originalEndsWithNewline != nil {
-			if *state.originalEndsWithNewline && !strings.HasSuffix(newContent, "\n") {
-				newContent += "\n"
-			}
-			if !*state.originalEndsWithNewline && strings.HasSuffix(newContent, "\n") {
-				newContent = strings.TrimSuffix(newContent, "\n")
-			}
-		}
-
-		writePath := state.path
-		displayPath := state.relativePath
-		moveTarget := strings.TrimSpace(state.movePath)
-		if moveTarget != "" {
-			abs, rel, err := resolvePath(moveTarget)
-			if err != nil {
-				return nil, &patchError{Message: err.Error()}
-			}
-			writePath = abs
-			displayPath = rel
-		}
-
-		if err := os.MkdirAll(filepath.Dir(writePath), 0o755); err != nil {
-			return nil, &patchError{Message: fmt.Sprintf("failed to create directory for %s: %v", displayPath, err)}
-		}
-
-		perm := state.originalMode & fs.ModePerm
-		if perm == 0 {
-			perm = 0o644
-		}
-
-		if err := os.WriteFile(writePath, []byte(newContent), perm); err != nil {
-			return nil, &patchError{Message: fmt.Sprintf("failed to write %s: %v", displayPath, err)}
-		}
-
-		if state.originalMode != 0 {
-			desired := (state.originalMode & fs.ModePerm) | (state.originalMode & (fs.ModeSetuid | fs.ModeSetgid | fs.ModeSticky))
-			if desired == 0 {
-				desired = perm
-			}
-
-			specialBits := state.originalMode & (fs.ModeSetuid | fs.ModeSetgid | fs.ModeSticky)
-			needsChmod := specialBits != 0
-			if !needsChmod {
-				info, statErr := os.Stat(writePath)
-				if statErr != nil {
-					return nil, &patchError{Message: fmt.Sprintf("failed to stat %s after write: %v", displayPath, statErr)}
-				}
-				current := info.Mode() & (fs.ModePerm | fs.ModeSetuid | fs.ModeSetgid | fs.ModeSticky)
-				if current != desired {
-					needsChmod = true
-				}
-			}
-
-			if needsChmod {
-				if err := os.Chmod(writePath, desired); err != nil {
-					return nil, &patchError{Message: fmt.Sprintf("failed to restore permissions for %s: %v", displayPath, err)}
-				}
-			}
-		}
-
-		if moveTarget != "" && writePath != state.path {
-			// Removing the original file mirrors the behaviour of the Rust implementation when renaming files.
-			if err := os.Remove(state.path); err != nil && !errors.Is(err, fs.ErrNotExist) {
-				return nil, &patchError{Message: fmt.Sprintf("failed to remove %s after move: %v", state.relativePath, err)}
-			}
-		}
-
-		status := "M"
-		if state.isNew {
-			status = "A"
-		}
-		results = append(results, fileResult{status: status, path: displayPath})
-	}
-
-	return results, nil
-}
-func normalizeLine(line string) string {
-	if line == "" {
-		return ""
-	}
-	var builder strings.Builder
-	builder.Grow(len(line))
-	for _, r := range line {
-		if unicode.IsSpace(r) {
-			continue
-		}
-		builder.WriteRune(r)
-	}
-	return builder.String()
-}
-
-func ensureNormalizedLines(state *fileState) []string {
-	if state == nil {
-		return nil
-	}
-	if !state.options.ignoreWhitespace {
-		return state.lines
-	}
-	if state.normalizedLines != nil {
-		return state.normalizedLines
-	}
-	normalized := make([]string, len(state.lines))
-	for i, line := range state.lines {
-		normalized[i] = normalizeLine(line)
-	}
-	state.normalizedLines = normalized
-	return normalized
-}
-
-func updateNormalizedLines(state *fileState, index, deleteCount int, replacement []string) {
-	if state == nil || !state.options.ignoreWhitespace {
-		return
-	}
-	normalized := ensureNormalizedLines(state)
-	replacementNormalized := make([]string, len(replacement))
-	for i, line := range replacement {
-		replacementNormalized[i] = normalizeLine(line)
-	}
-	state.normalizedLines = splice(normalized, index, deleteCount, replacementNormalized)
-}
-
-func applyHunk(state *fileState, hunk patchHunk) error {
-	if state == nil {
-		return errors.New("missing file state")
-	}
-
-	before := hunk.before
-	after := hunk.after
-
-	if len(before) == 0 {
-		insertionIndex := len(state.lines)
-		if insertionIndex > 0 && state.lines[insertionIndex-1] == "" {
-			insertionIndex--
-		}
-		state.lines = splice(state.lines, insertionIndex, 0, after)
-		updateNormalizedLines(state, insertionIndex, 0, after)
-		state.cursor = insertionIndex + len(after)
-		return nil
-	}
-
-	matchIndex := findSubsequence(state.lines, before, state.cursor, hunk.atEOF)
-	if matchIndex == -1 {
-		matchIndex = findSubsequence(state.lines, before, 0, hunk.atEOF)
-	}
-
-	if matchIndex == -1 && state.options.ignoreWhitespace {
-		normalizedBefore := make([]string, len(before))
-		for i, line := range before {
-			normalizedBefore[i] = normalizeLine(line)
-		}
-		normalizedLines := ensureNormalizedLines(state)
-		matchIndex = findSubsequence(normalizedLines, normalizedBefore, state.cursor, hunk.atEOF)
-		if matchIndex == -1 {
-			matchIndex = findSubsequence(normalizedLines, normalizedBefore, 0, hunk.atEOF)
-		}
-	}
-
-	if matchIndex == -1 {
-		message := fmt.Sprintf("Hunk not found in %s.", state.relativePath)
-		original := state.originalContent
-		if original == "" {
-			original = strings.Join(state.lines, "\n")
-		}
-		return &patchError{
-			Message:         message,
-			Code:            "HUNK_NOT_FOUND",
-			RelativePath:    state.relativePath,
-			OriginalContent: original,
-		}
-	}
-
-	state.lines = splice(state.lines, matchIndex, len(before), after)
-	updateNormalizedLines(state, matchIndex, len(before), after)
-	state.cursor = matchIndex + len(after)
-	return nil
-}
-
-func splice(target []string, index, deleteCount int, replacement []string) []string {
-	if deleteCount == 0 && len(replacement) == 0 {
-		return target
-	}
-	result := make([]string, 0, len(target)-deleteCount+len(replacement))
-	result = append(result, target[:index]...)
-	result = append(result, replacement...)
-	result = append(result, target[index+deleteCount:]...)
-	return result
-}
-
-func findSubsequence(haystack, needle []string, startIndex int, requireEOF bool) int {
-	if len(needle) == 0 {
-		return -1
-	}
-	if startIndex < 0 {
-		startIndex = 0
-	}
-	if startIndex > len(haystack) {
-		startIndex = len(haystack)
-	}
-	for i := startIndex; i <= len(haystack)-len(needle); i++ {
-		matched := true
-		for j := range needle {
-			if haystack[i+j] != needle[j] {
-				matched = false
-				break
-			}
-		}
-		if matched {
-			if requireEOF && !matchSatisfiesEOF(haystack, i, len(needle)) {
-				continue
-			}
-			return i
-		}
-	}
-	return -1
-}
-func matchSatisfiesEOF(lines []string, start, length int) bool {
-	end := start + length
-	if end >= len(lines) {
-		return true
-	}
-	for _, line := range lines[end:] {
-		if line != "" {
-			return false
-		}
-	}
-	return true
-}
-
-func enhanceHunkError(err error, state *fileState, hunk patchHunk, number int) *patchError {
-	var pe *patchError
-	if errors.As(err, &pe) {
-		// Use the existing error instance so we preserve any preset metadata.
-	} else {
-		pe = &patchError{Message: err.Error()}
-	}
-
-	statuses := append([]hunkStatus{}, state.hunkStatuses...)
-	if pe != nil && len(pe.HunkStatuses) > 0 {
-		statuses = append(statuses, pe.HunkStatuses...)
-	}
-	statuses = append(statuses, hunkStatus{Number: number, Status: "no-match"})
-	pe.HunkStatuses = statuses
-
-	if pe.Code == "" {
-		pe.Code = "HUNK_NOT_FOUND"
-	}
-	if pe.RelativePath == "" && state != nil {
-		pe.RelativePath = state.relativePath
-	}
-	if pe.OriginalContent == "" && state != nil {
-		if state.originalContent != "" {
-			pe.OriginalContent = state.originalContent
-		} else {
-			pe.OriginalContent = strings.Join(state.lines, "\n")
-		}
-	}
-	if pe.FailedHunk == nil {
-		rawLines := append([]string(nil), hunk.rawPatchLines...)
-		pe.FailedHunk = &failedHunk{Number: number, RawPatchLines: rawLines}
-	}
-	return pe
-}
-
-func describeHunkStatuses(statuses []hunkStatus) string {
-	if len(statuses) == 0 {
-		return ""
-	}
-	var applied []string
-	var failed string
-	for _, status := range statuses {
-		if status.Status == "applied" {
-			applied = append(applied, fmt.Sprintf("%d", status.Number))
-			continue
-		}
-		if failed == "" {
-			failed = fmt.Sprintf("No match for hunk %d.", status.Number)
-		}
-	}
-
-	parts := make([]string, 0, 2)
-	if len(applied) > 0 {
-		parts = append(parts, fmt.Sprintf("Hunks applied: %s.", strings.Join(applied, ", ")))
-	}
-	if failed != "" {
-		parts = append(parts, failed)
-	}
-	return strings.Join(parts, "\n")
-}
-
-func formatPatchError(err *patchError) string {
-	if err == nil {
-		return "Unknown error occurred."
-	}
-	message := err.Message
-	if message == "" {
-		message = "Unknown error occurred."
-	}
-	code := err.Code
-	if code == "HUNK_NOT_FOUND" || strings.Contains(strings.ToLower(message), "hunk not found") {
-		relativePath := err.RelativePath
-		if relativePath == "" {
-			relativePath = "unknown file"
-		}
-		displayPath := relativePath
-		if !strings.HasPrefix(displayPath, "./") {
-			displayPath = "./" + displayPath
-		}
-		var parts []string
-		parts = append(parts, message)
-		if summary := describeHunkStatuses(err.HunkStatuses); summary != "" {
-			parts = append(parts, "", summary)
-		}
-		if err.FailedHunk != nil && len(err.FailedHunk.RawPatchLines) > 0 {
-			parts = append(parts, "", "Offending hunk:")
-			parts = append(parts, strings.Join(err.FailedHunk.RawPatchLines, "\n"))
-		}
-		if err.OriginalContent != "" {
-			parts = append(parts, "", fmt.Sprintf("Full content of file: %s::::", displayPath), err.OriginalContent)
-		}
-		return strings.Join(parts, "\n")
-	}
-	return message
 }
 
 func registerBuiltinInternalCommands(executor *CommandExecutor) error {

--- a/pkg/patch/apply.go
+++ b/pkg/patch/apply.go
@@ -1,0 +1,342 @@
+package patch
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"strings"
+	"unicode"
+)
+
+type workspace interface {
+	Ensure(path string, create bool) (*state, error)
+	Delete(path string) error
+	Commit() ([]Result, error)
+}
+
+type state struct {
+	path                    string
+	relativePath            string
+	lines                   []string
+	normalizedLines         []string
+	originalContent         string
+	originalEndsWithNewline *bool
+	originalMode            fs.FileMode
+	touched                 bool
+	cursor                  int
+	hunkStatuses            []HunkStatus
+	isNew                   bool
+	movePath                string
+	options                 Options
+}
+
+func apply(ctx context.Context, operations []Operation, ws workspace) ([]Result, error) {
+	if ws == nil {
+		return nil, errors.New("nil workspace")
+	}
+	for _, op := range operations {
+		if ctx.Err() != nil {
+			return nil, &Error{Message: ctx.Err().Error()}
+		}
+		switch op.Type {
+		case OperationDelete:
+			if err := ws.Delete(op.Path); err != nil {
+				var pe *Error
+				if errors.As(err, &pe) {
+					return nil, pe
+				}
+				return nil, &Error{Message: err.Error()}
+			}
+		case OperationUpdate, OperationAdd:
+			state, err := ws.Ensure(op.Path, op.Type == OperationAdd)
+			if err != nil {
+				var pe *Error
+				if errors.As(err, &pe) {
+					return nil, pe
+				}
+				return nil, &Error{Message: err.Error()}
+			}
+			state.cursor = 0
+			state.hunkStatuses = nil
+			for index, hunk := range op.Hunks {
+				if ctx.Err() != nil {
+					return nil, &Error{Message: ctx.Err().Error()}
+				}
+				number := index + 1
+				if err := applyHunk(state, hunk); err != nil {
+					return nil, enhanceHunkError(err, state, hunk, number)
+				}
+				state.hunkStatuses = append(state.hunkStatuses, HunkStatus{Number: number, Status: "applied"})
+				state.touched = true
+			}
+			trimmedMove := strings.TrimSpace(op.MovePath)
+			if trimmedMove != "" {
+				state.movePath = trimmedMove
+				state.touched = true
+			}
+		default:
+			return nil, &Error{Message: fmt.Sprintf("unsupported patch operation for %s: %s", op.Path, op.Type)}
+		}
+	}
+	results, err := ws.Commit()
+	if err != nil {
+		var pe *Error
+		if errors.As(err, &pe) {
+			return nil, pe
+		}
+		return nil, &Error{Message: err.Error()}
+	}
+	return results, nil
+}
+
+func applyHunk(state *state, hunk Hunk) error {
+	if state == nil {
+		return errors.New("missing file state")
+	}
+
+	before := hunk.Before
+	after := hunk.After
+
+	if len(before) == 0 {
+		insertionIndex := len(state.lines)
+		if insertionIndex > 0 && state.lines[insertionIndex-1] == "" {
+			insertionIndex--
+		}
+		state.lines = splice(state.lines, insertionIndex, 0, after)
+		updateNormalizedLines(state, insertionIndex, 0, after)
+		state.cursor = insertionIndex + len(after)
+		return nil
+	}
+
+	matchIndex := findSubsequence(state.lines, before, state.cursor, hunk.AtEOF)
+	if matchIndex == -1 {
+		matchIndex = findSubsequence(state.lines, before, 0, hunk.AtEOF)
+	}
+
+	if matchIndex == -1 && state.options.IgnoreWhitespace {
+		normalizedBefore := make([]string, len(before))
+		for i, line := range before {
+			normalizedBefore[i] = normalizeLine(line)
+		}
+		normalizedLines := ensureNormalizedLines(state)
+		matchIndex = findSubsequence(normalizedLines, normalizedBefore, state.cursor, hunk.AtEOF)
+		if matchIndex == -1 {
+			matchIndex = findSubsequence(normalizedLines, normalizedBefore, 0, hunk.AtEOF)
+		}
+	}
+
+	if matchIndex == -1 {
+		message := fmt.Sprintf("Hunk not found in %s.", state.relativePath)
+		original := state.originalContent
+		if original == "" {
+			original = strings.Join(state.lines, "\n")
+		}
+		return &Error{
+			Message:         message,
+			Code:            "HUNK_NOT_FOUND",
+			RelativePath:    state.relativePath,
+			OriginalContent: original,
+		}
+	}
+
+	state.lines = splice(state.lines, matchIndex, len(before), after)
+	updateNormalizedLines(state, matchIndex, len(before), after)
+	state.cursor = matchIndex + len(after)
+	return nil
+}
+
+func splice(target []string, index, deleteCount int, replacement []string) []string {
+	if deleteCount == 0 && len(replacement) == 0 {
+		return target
+	}
+	result := make([]string, 0, len(target)-deleteCount+len(replacement))
+	result = append(result, target[:index]...)
+	result = append(result, replacement...)
+	result = append(result, target[index+deleteCount:]...)
+	return result
+}
+
+func findSubsequence(haystack, needle []string, startIndex int, requireEOF bool) int {
+	if len(needle) == 0 {
+		return -1
+	}
+	if startIndex < 0 {
+		startIndex = 0
+	}
+	if startIndex > len(haystack) {
+		startIndex = len(haystack)
+	}
+	for i := startIndex; i <= len(haystack)-len(needle); i++ {
+		matched := true
+		for j := range needle {
+			if haystack[i+j] != needle[j] {
+				matched = false
+				break
+			}
+		}
+		if matched {
+			if requireEOF && !matchSatisfiesEOF(haystack, i, len(needle)) {
+				continue
+			}
+			return i
+		}
+	}
+	return -1
+}
+
+func matchSatisfiesEOF(lines []string, start, length int) bool {
+	end := start + length
+	if end >= len(lines) {
+		return true
+	}
+	for _, line := range lines[end:] {
+		if line != "" {
+			return false
+		}
+	}
+	return true
+}
+
+func ensureNormalizedLines(state *state) []string {
+	if state == nil {
+		return nil
+	}
+	if !state.options.IgnoreWhitespace {
+		return state.lines
+	}
+	if state.normalizedLines != nil {
+		return state.normalizedLines
+	}
+	normalized := make([]string, len(state.lines))
+	for i, line := range state.lines {
+		normalized[i] = normalizeLine(line)
+	}
+	state.normalizedLines = normalized
+	return normalized
+}
+
+func updateNormalizedLines(state *state, index, deleteCount int, replacement []string) {
+	if state == nil || !state.options.IgnoreWhitespace {
+		return
+	}
+	normalized := ensureNormalizedLines(state)
+	replacementNormalized := make([]string, len(replacement))
+	for i, line := range replacement {
+		replacementNormalized[i] = normalizeLine(line)
+	}
+	state.normalizedLines = splice(normalized, index, deleteCount, replacementNormalized)
+}
+
+func normalizeLine(line string) string {
+	if line == "" {
+		return ""
+	}
+	var builder strings.Builder
+	builder.Grow(len(line))
+	for _, r := range line {
+		if unicode.IsSpace(r) {
+			continue
+		}
+		builder.WriteRune(r)
+	}
+	return builder.String()
+}
+
+func enhanceHunkError(err error, state *state, hunk Hunk, number int) *Error {
+	var pe *Error
+	if errors.As(err, &pe) {
+		// Use existing instance to preserve metadata.
+	} else {
+		pe = &Error{Message: err.Error()}
+	}
+
+	statuses := append([]HunkStatus{}, state.hunkStatuses...)
+	if pe != nil && len(pe.HunkStatuses) > 0 {
+		statuses = append(statuses, pe.HunkStatuses...)
+	}
+	statuses = append(statuses, HunkStatus{Number: number, Status: "no-match"})
+	pe.HunkStatuses = statuses
+
+	if pe.Code == "" {
+		pe.Code = "HUNK_NOT_FOUND"
+	}
+	if pe.RelativePath == "" && state != nil {
+		pe.RelativePath = state.relativePath
+	}
+	if pe.OriginalContent == "" && state != nil {
+		if state.originalContent != "" {
+			pe.OriginalContent = state.originalContent
+		} else {
+			pe.OriginalContent = strings.Join(state.lines, "\n")
+		}
+	}
+	if pe.FailedHunk == nil {
+		rawLines := append([]string(nil), hunk.RawPatchLines...)
+		pe.FailedHunk = &FailedHunk{Number: number, RawPatchLines: rawLines}
+	}
+	return pe
+}
+
+func describeHunkStatuses(statuses []HunkStatus) string {
+	if len(statuses) == 0 {
+		return ""
+	}
+	var applied []string
+	var failed string
+	for _, status := range statuses {
+		if status.Status == "applied" {
+			applied = append(applied, fmt.Sprintf("%d", status.Number))
+			continue
+		}
+		if failed == "" {
+			failed = fmt.Sprintf("No match for hunk %d.", status.Number)
+		}
+	}
+
+	parts := make([]string, 0, 2)
+	if len(applied) > 0 {
+		parts = append(parts, fmt.Sprintf("Hunks applied: %s.", strings.Join(applied, ", ")))
+	}
+	if failed != "" {
+		parts = append(parts, failed)
+	}
+	return strings.Join(parts, "\n")
+}
+
+// FormatError renders Error values into a human readable message suitable for
+// surfacing to end users.
+func FormatError(err *Error) string {
+	if err == nil {
+		return "Unknown error occurred."
+	}
+	message := err.Message
+	if message == "" {
+		message = "Unknown error occurred."
+	}
+	code := err.Code
+	if code == "HUNK_NOT_FOUND" || strings.Contains(strings.ToLower(message), "hunk not found") {
+		relativePath := err.RelativePath
+		if relativePath == "" {
+			relativePath = "unknown file"
+		}
+		displayPath := relativePath
+		if !strings.HasPrefix(displayPath, "./") {
+			displayPath = "./" + displayPath
+		}
+		var parts []string
+		parts = append(parts, message)
+		if summary := describeHunkStatuses(err.HunkStatuses); summary != "" {
+			parts = append(parts, "", summary)
+		}
+		if err.FailedHunk != nil && len(err.FailedHunk.RawPatchLines) > 0 {
+			parts = append(parts, "", "Offending hunk:")
+			parts = append(parts, strings.Join(err.FailedHunk.RawPatchLines, "\n"))
+		}
+		if err.OriginalContent != "" {
+			parts = append(parts, "", fmt.Sprintf("Full content of file: %s::::", displayPath), err.OriginalContent)
+		}
+		return strings.Join(parts, "\n")
+	}
+	return message
+}

--- a/pkg/patch/doc.go
+++ b/pkg/patch/doc.go
@@ -1,0 +1,7 @@
+// Package patch provides helpers for parsing and applying unified-diff style patches.
+//
+// The package is extracted from GoAgent's internal command implementation so that it can be
+// reused by other tools. It exposes primitives to parse patch payloads, apply them to the
+// filesystem, or operate on in-memory documents which makes it straightforward to embed in
+// editors and testing utilities.
+package patch

--- a/pkg/patch/filesystem.go
+++ b/pkg/patch/filesystem.go
@@ -1,0 +1,248 @@
+package patch
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// ApplyFilesystem applies operations to the OS filesystem.
+func ApplyFilesystem(ctx context.Context, operations []Operation, opts FilesystemOptions) ([]Result, error) {
+	ws, err := newFilesystemWorkspace(opts)
+	if err != nil {
+		return nil, err
+	}
+	return apply(ctx, operations, ws)
+}
+
+// ApplyFilesystemPatch parses a raw patch payload and applies it to the filesystem.
+func ApplyFilesystemPatch(ctx context.Context, patchBody string, opts FilesystemOptions) ([]Result, error) {
+	operations, err := Parse(patchBody)
+	if err != nil {
+		return nil, err
+	}
+	return ApplyFilesystem(ctx, operations, opts)
+}
+
+type filesystemWorkspace struct {
+	options    Options
+	workingDir string
+	states     map[string]*state
+	deletions  []Result
+}
+
+func newFilesystemWorkspace(opts FilesystemOptions) (*filesystemWorkspace, error) {
+	workingDir := strings.TrimSpace(opts.WorkingDir)
+	if workingDir == "" {
+		wd, err := os.Getwd()
+		if err != nil {
+			return nil, fmt.Errorf("failed to determine working directory: %w", err)
+		}
+		workingDir = wd
+	}
+	if abs, err := filepath.Abs(workingDir); err == nil {
+		workingDir = abs
+	}
+	return &filesystemWorkspace{
+		options:    opts.Options,
+		workingDir: workingDir,
+		states:     make(map[string]*state),
+	}, nil
+}
+
+func (ws *filesystemWorkspace) Ensure(path string, create bool) (*state, error) {
+	abs, rel, err := ws.resolvePath(path)
+	if err != nil {
+		return nil, err
+	}
+	if state, ok := ws.states[abs]; ok {
+		state.options = ws.options
+		if ws.options.IgnoreWhitespace {
+			state.normalizedLines = ensureNormalizedLines(state)
+		} else {
+			state.normalizedLines = nil
+		}
+		return state, nil
+	}
+
+	info, err := os.Stat(abs)
+	switch {
+	case err == nil && create:
+		if info.IsDir() {
+			return nil, fmt.Errorf("cannot add directory %s", rel)
+		}
+		state := &state{
+			path:         abs,
+			relativePath: rel,
+			lines:        []string{},
+			options:      ws.options,
+			isNew:        true,
+		}
+		if ws.options.IgnoreWhitespace {
+			state.normalizedLines = []string{}
+		}
+		ws.states[abs] = state
+		return state, nil
+	case err == nil:
+		if info.IsDir() {
+			return nil, fmt.Errorf("cannot patch directory %s", rel)
+		}
+		content, readErr := os.ReadFile(abs)
+		if readErr != nil {
+			return nil, fmt.Errorf("failed to read %s: %v", rel, readErr)
+		}
+		normalized := strings.ReplaceAll(string(content), "\r\n", "\n")
+		normalized = strings.ReplaceAll(normalized, "\r", "\n")
+		lines := strings.Split(normalized, "\n")
+		ends := strings.HasSuffix(normalized, "\n")
+		state := &state{
+			path:                    abs,
+			relativePath:            rel,
+			lines:                   lines,
+			originalContent:         string(content),
+			originalEndsWithNewline: &ends,
+			originalMode:            info.Mode(),
+			options:                 ws.options,
+		}
+		if ws.options.IgnoreWhitespace {
+			state.normalizedLines = ensureNormalizedLines(state)
+		}
+		ws.states[abs] = state
+		return state, nil
+	case errors.Is(err, fs.ErrNotExist):
+		if !create {
+			return nil, fmt.Errorf("failed to read %s: file does not exist", rel)
+		}
+		state := &state{
+			path:         abs,
+			relativePath: rel,
+			lines:        []string{},
+			options:      ws.options,
+			isNew:        true,
+		}
+		if ws.options.IgnoreWhitespace {
+			state.normalizedLines = []string{}
+		}
+		ws.states[abs] = state
+		return state, nil
+	default:
+		return nil, fmt.Errorf("failed to stat %s: %v", rel, err)
+	}
+}
+
+func (ws *filesystemWorkspace) Delete(path string) error {
+	abs, rel, err := ws.resolvePath(path)
+	if err != nil {
+		return err
+	}
+	info, statErr := os.Stat(abs)
+	if statErr != nil || info.IsDir() {
+		return &Error{Message: fmt.Sprintf("Failed to delete file %s", rel)}
+	}
+	if err := os.Remove(abs); err != nil {
+		return &Error{Message: fmt.Sprintf("Failed to delete file %s", rel)}
+	}
+	ws.deletions = append(ws.deletions, Result{Status: "D", Path: rel})
+	return nil
+}
+
+func (ws *filesystemWorkspace) Commit() ([]Result, error) {
+	results := append([]Result{}, ws.deletions...)
+	for _, state := range ws.states {
+		if !state.touched {
+			continue
+		}
+		newContent := strings.Join(state.lines, "\n")
+		if state.originalEndsWithNewline != nil {
+			if *state.originalEndsWithNewline && !strings.HasSuffix(newContent, "\n") {
+				newContent += "\n"
+			}
+			if !*state.originalEndsWithNewline && strings.HasSuffix(newContent, "\n") {
+				newContent = strings.TrimSuffix(newContent, "\n")
+			}
+		}
+
+		writePath := state.path
+		displayPath := state.relativePath
+		moveTarget := strings.TrimSpace(state.movePath)
+		if moveTarget != "" {
+			abs, rel, err := ws.resolvePath(moveTarget)
+			if err != nil {
+				return nil, err
+			}
+			writePath = abs
+			displayPath = rel
+		}
+
+		if err := os.MkdirAll(filepath.Dir(writePath), 0o755); err != nil {
+			return nil, &Error{Message: fmt.Sprintf("failed to create directory for %s: %v", displayPath, err)}
+		}
+
+		perm := state.originalMode & fs.ModePerm
+		if perm == 0 {
+			perm = 0o644
+		}
+
+		if err := os.WriteFile(writePath, []byte(newContent), perm); err != nil {
+			return nil, &Error{Message: fmt.Sprintf("failed to write %s: %v", displayPath, err)}
+		}
+
+		if state.originalMode != 0 {
+			desired := (state.originalMode & fs.ModePerm) | (state.originalMode & (fs.ModeSetuid | fs.ModeSetgid | fs.ModeSticky))
+			if desired == 0 {
+				desired = perm
+			}
+
+			specialBits := state.originalMode & (fs.ModeSetuid | fs.ModeSetgid | fs.ModeSticky)
+			needsChmod := specialBits != 0
+			if !needsChmod {
+				info, statErr := os.Stat(writePath)
+				if statErr != nil {
+					return nil, &Error{Message: fmt.Sprintf("failed to stat %s after write: %v", displayPath, statErr)}
+				}
+				current := info.Mode() & (fs.ModePerm | fs.ModeSetuid | fs.ModeSetgid | fs.ModeSticky)
+				if current != desired {
+					needsChmod = true
+				}
+			}
+
+			if needsChmod {
+				if err := os.Chmod(writePath, desired); err != nil {
+					return nil, &Error{Message: fmt.Sprintf("failed to restore permissions for %s: %v", displayPath, err)}
+				}
+			}
+		}
+
+		if moveTarget != "" && writePath != state.path {
+			if err := os.Remove(state.path); err != nil && !errors.Is(err, fs.ErrNotExist) {
+				return nil, &Error{Message: fmt.Sprintf("failed to remove %s after move: %v", state.relativePath, err)}
+			}
+		}
+
+		status := "M"
+		if state.isNew {
+			status = "A"
+		}
+		results = append(results, Result{Status: status, Path: displayPath})
+	}
+	return results, nil
+}
+
+func (ws *filesystemWorkspace) resolvePath(relative string) (string, string, error) {
+	rel := strings.TrimSpace(relative)
+	if rel == "" {
+		return "", "", fmt.Errorf("invalid patch path")
+	}
+	cleaned := filepath.Clean(rel)
+	var abs string
+	if filepath.IsAbs(cleaned) {
+		abs = filepath.Clean(cleaned)
+	} else {
+		abs = filepath.Clean(filepath.Join(ws.workingDir, cleaned))
+	}
+	return abs, cleaned, nil
+}

--- a/pkg/patch/memory.go
+++ b/pkg/patch/memory.go
@@ -1,0 +1,156 @@
+package patch
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"strings"
+)
+
+// ApplyToMemory applies operations to an in-memory document store represented by a map.
+// The provided map is copied before mutation and the updated snapshot is returned.
+func ApplyToMemory(ctx context.Context, operations []Operation, files map[string]string, opts Options) (map[string]string, []Result, error) {
+	snapshot := make(map[string]string, len(files))
+	for k, v := range files {
+		snapshot[k] = v
+	}
+	ws := newMemoryWorkspace(snapshot, opts)
+	results, err := apply(ctx, operations, ws)
+	if err != nil {
+		return nil, nil, err
+	}
+	return ws.files, results, nil
+}
+
+// ApplyMemoryPatch parses a raw patch payload and applies it to an in-memory map of files.
+func ApplyMemoryPatch(ctx context.Context, patchBody string, files map[string]string, opts Options) (map[string]string, []Result, error) {
+	operations, err := Parse(patchBody)
+	if err != nil {
+		return nil, nil, err
+	}
+	return ApplyToMemory(ctx, operations, files, opts)
+}
+
+type memoryWorkspace struct {
+	options   Options
+	files     map[string]string
+	states    map[string]*state
+	deletions []Result
+}
+
+func newMemoryWorkspace(files map[string]string, opts Options) *memoryWorkspace {
+	return &memoryWorkspace{
+		options: opts,
+		files:   files,
+		states:  make(map[string]*state),
+	}
+}
+
+func (ws *memoryWorkspace) Ensure(path string, create bool) (*state, error) {
+	rel := filepath.Clean(strings.TrimSpace(path))
+	if rel == "" || rel == "." {
+		return nil, fmt.Errorf("invalid patch path")
+	}
+	if state, ok := ws.states[rel]; ok {
+		state.options = ws.options
+		if ws.options.IgnoreWhitespace {
+			state.normalizedLines = ensureNormalizedLines(state)
+		} else {
+			state.normalizedLines = nil
+		}
+		return state, nil
+	}
+
+	content, ok := ws.files[rel]
+	if !ok {
+		if !create {
+			return nil, fmt.Errorf("failed to read %s: file does not exist", rel)
+		}
+		state := &state{
+			path:         rel,
+			relativePath: rel,
+			lines:        []string{},
+			options:      ws.options,
+			isNew:        true,
+		}
+		if ws.options.IgnoreWhitespace {
+			state.normalizedLines = []string{}
+		}
+		ws.states[rel] = state
+		return state, nil
+	}
+
+	normalized := strings.ReplaceAll(content, "\r\n", "\n")
+	normalized = strings.ReplaceAll(normalized, "\r", "\n")
+	lines := strings.Split(normalized, "\n")
+	ends := strings.HasSuffix(normalized, "\n")
+	state := &state{
+		path:                    rel,
+		relativePath:            rel,
+		lines:                   lines,
+		originalContent:         content,
+		originalEndsWithNewline: &ends,
+		options:                 ws.options,
+	}
+	if ws.options.IgnoreWhitespace {
+		state.normalizedLines = ensureNormalizedLines(state)
+	}
+	ws.states[rel] = state
+	return state, nil
+}
+
+func (ws *memoryWorkspace) Delete(path string) error {
+	rel := filepath.Clean(strings.TrimSpace(path))
+	if rel == "" || rel == "." {
+		return fmt.Errorf("invalid patch path")
+	}
+	if _, ok := ws.files[rel]; !ok {
+		return &Error{Message: fmt.Sprintf("Failed to delete file %s", rel)}
+	}
+	delete(ws.files, rel)
+	delete(ws.states, rel)
+	ws.deletions = append(ws.deletions, Result{Status: "D", Path: rel})
+	return nil
+}
+
+func (ws *memoryWorkspace) Commit() ([]Result, error) {
+	results := append([]Result{}, ws.deletions...)
+	for key, state := range ws.states {
+		if !state.touched {
+			continue
+		}
+		newContent := strings.Join(state.lines, "\n")
+		if state.originalEndsWithNewline != nil {
+			if *state.originalEndsWithNewline && !strings.HasSuffix(newContent, "\n") {
+				newContent += "\n"
+			}
+			if !*state.originalEndsWithNewline && strings.HasSuffix(newContent, "\n") {
+				newContent = strings.TrimSuffix(newContent, "\n")
+			}
+		}
+
+		writeKey := key
+		display := state.relativePath
+		moveTarget := strings.TrimSpace(state.movePath)
+		if moveTarget != "" {
+			cleaned := filepath.Clean(moveTarget)
+			if cleaned == "" || cleaned == "." {
+				return nil, fmt.Errorf("invalid patch path")
+			}
+			writeKey = cleaned
+			display = cleaned
+		}
+
+		ws.files[writeKey] = newContent
+		if moveTarget != "" && writeKey != key {
+			delete(ws.files, key)
+		}
+
+		status := "M"
+		if state.isNew {
+			status = "A"
+		}
+		results = append(results, Result{Status: status, Path: display})
+	}
+	return results, nil
+}

--- a/pkg/patch/parse.go
+++ b/pkg/patch/parse.go
@@ -1,0 +1,273 @@
+package patch
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// OperationType identifies the kind of change described by a patch operation.
+type OperationType string
+
+const (
+	// OperationAdd represents an "*** Add File" directive.
+	OperationAdd OperationType = "add"
+	// OperationUpdate represents an "*** Update File" directive.
+	OperationUpdate OperationType = "update"
+	// OperationDelete represents an "*** Delete File" directive.
+	OperationDelete OperationType = "delete"
+)
+
+// Operation describes a high-level instruction contained in a patch payload.
+//
+// The exported fields make it possible to inspect the parsed structure when
+// building tooling around the parser.
+type Operation struct {
+	Type     OperationType
+	Path     string
+	MovePath string
+	Hunks    []Hunk
+}
+
+// Hunk captures a unified-diff hunk belonging to an Operation.
+type Hunk struct {
+	Header        string
+	Lines         []string
+	RawPatchLines []string
+	Before        []string
+	After         []string
+	AtEOF         bool
+}
+
+// HunkStatus tracks how a hunk was applied when processing a patch.
+type HunkStatus struct {
+	Number int    `json:"number"`
+	Status string `json:"status"`
+}
+
+// FailedHunk stores the raw lines of the hunk that could not be applied.
+type FailedHunk struct {
+	Number        int      `json:"number"`
+	RawPatchLines []string `json:"rawPatchLines"`
+}
+
+// Error represents a structured failure while applying a patch. It satisfies
+// the error interface so it can be returned directly from Apply* helpers.
+type Error struct {
+	Message         string
+	Code            string
+	RelativePath    string
+	OriginalContent string
+	HunkStatuses    []HunkStatus
+	FailedHunk      *FailedHunk
+}
+
+// Error implements the error interface.
+func (e *Error) Error() string {
+	if e == nil {
+		return ""
+	}
+	if e.Message != "" {
+		return e.Message
+	}
+	return "patch error"
+}
+
+// Options configures how patch application behaves for both filesystem and
+// in-memory operations.
+type Options struct {
+	IgnoreWhitespace bool
+}
+
+// FilesystemOptions augments Options with a working directory used to resolve
+// relative paths when touching the local filesystem.
+type FilesystemOptions struct {
+	Options
+	WorkingDir string
+}
+
+// Result describes the outcome for a single file when applying a patch.
+type Result struct {
+	Status string
+	Path   string
+}
+
+// Parse converts the textual representation of an apply_patch payload into a
+// slice of operations that can later be applied.
+func Parse(input string) ([]Operation, error) {
+	lines := splitLines(input)
+	var (
+		operations  []Operation
+		currentOp   *Operation
+		currentHunk *Hunk
+		inside      bool
+	)
+
+	flushHunk := func() error {
+		if currentHunk == nil {
+			return nil
+		}
+		if currentOp == nil {
+			return errors.New("hunk encountered before file directive")
+		}
+		parsed, err := parseHunk(currentHunk.Lines, currentOp.Path, currentHunk.Header)
+		if err != nil {
+			return err
+		}
+		currentOp.Hunks = append(currentOp.Hunks, parsed)
+		currentHunk = nil
+		return nil
+	}
+
+	flushOp := func() error {
+		if currentOp == nil {
+			return nil
+		}
+		if err := flushHunk(); err != nil {
+			return err
+		}
+		if len(currentOp.Hunks) == 0 && !(currentOp.Type == OperationUpdate && strings.TrimSpace(currentOp.MovePath) != "") {
+			return fmt.Errorf("no hunks provided for %s", currentOp.Path)
+		}
+		operations = append(operations, *currentOp)
+		currentOp = nil
+		return nil
+	}
+
+	for _, rawLine := range lines {
+		line := rawLine
+		switch line {
+		case "*** Begin Patch":
+			inside = true
+			continue
+		case "*** End Patch":
+			if inside {
+				if err := flushOp(); err != nil {
+					return nil, err
+				}
+			}
+			inside = false
+			continue
+		}
+
+		if !inside {
+			continue
+		}
+
+		trimmed := strings.TrimSpace(line)
+
+		if trimmed == "*** End of File" {
+			if currentOp == nil {
+				return nil, fmt.Errorf("end-of-file marker encountered before a file directive")
+			}
+			if currentHunk == nil {
+				currentHunk = &Hunk{}
+			}
+			currentHunk.Lines = append(currentHunk.Lines, line)
+			continue
+		}
+
+		if strings.HasPrefix(trimmed, "*** Move to: ") {
+			if currentOp == nil {
+				return nil, fmt.Errorf("move directive encountered before a file directive")
+			}
+			if currentOp.Type != OperationUpdate {
+				return nil, fmt.Errorf("move directive only allowed for update operations")
+			}
+			currentOp.MovePath = strings.TrimSpace(strings.TrimPrefix(trimmed, "*** Move to: "))
+			continue
+		}
+
+		if strings.HasPrefix(trimmed, "*** Delete File: ") {
+			if err := flushOp(); err != nil {
+				return nil, err
+			}
+			path := strings.TrimSpace(strings.TrimPrefix(trimmed, "*** Delete File: "))
+			operations = append(operations, Operation{Type: OperationDelete, Path: path})
+			currentOp = nil
+			currentHunk = nil
+			continue
+		}
+
+		if strings.HasPrefix(trimmed, "*** ") {
+			if err := flushOp(); err != nil {
+				return nil, err
+			}
+			if updatePath, ok := strings.CutPrefix(trimmed, "*** Update File: "); ok {
+				path := strings.TrimSpace(updatePath)
+				currentOp = &Operation{Type: OperationUpdate, Path: path}
+				continue
+			}
+			if addPath, ok := strings.CutPrefix(trimmed, "*** Add File: "); ok {
+				path := strings.TrimSpace(addPath)
+				currentOp = &Operation{Type: OperationAdd, Path: path}
+				continue
+			}
+			return nil, fmt.Errorf("unsupported patch directive: %s", line)
+		}
+
+		if currentOp == nil {
+			if trimmed == "" {
+				continue
+			}
+			return nil, fmt.Errorf("diff content appeared before a file directive: %q", line)
+		}
+
+		if strings.HasPrefix(line, "@@") {
+			if err := flushHunk(); err != nil {
+				return nil, err
+			}
+			currentHunk = &Hunk{Header: line}
+			continue
+		}
+
+		if currentHunk == nil {
+			currentHunk = &Hunk{}
+		}
+		currentHunk.Lines = append(currentHunk.Lines, line)
+	}
+
+	if inside {
+		return nil, errors.New("missing *** End Patch terminator")
+	}
+
+	if err := flushOp(); err != nil {
+		return nil, err
+	}
+
+	return operations, nil
+}
+
+func parseHunk(lines []string, filePath, header string) (Hunk, error) {
+	hunk := Hunk{Header: header}
+	hunk.Lines = append([]string(nil), lines...)
+	for _, raw := range lines {
+		switch {
+		case strings.HasPrefix(raw, "+"):
+			hunk.After = append(hunk.After, raw[1:])
+		case strings.HasPrefix(raw, "-"):
+			hunk.Before = append(hunk.Before, raw[1:])
+		case strings.HasPrefix(raw, " "):
+			value := raw[1:]
+			hunk.Before = append(hunk.Before, value)
+			hunk.After = append(hunk.After, value)
+		case strings.TrimSpace(raw) == "*** End of File":
+			hunk.AtEOF = true
+		case raw == "\\ No newline at end of file":
+			// ignore marker
+		default:
+			return Hunk{}, fmt.Errorf("unsupported hunk line in %s: %q", filePath, raw)
+		}
+	}
+	if header != "" {
+		hunk.RawPatchLines = append(hunk.RawPatchLines, header)
+	}
+	hunk.RawPatchLines = append(hunk.RawPatchLines, lines...)
+	return hunk, nil
+}
+
+func splitLines(input string) []string {
+	normalized := strings.ReplaceAll(input, "\r\n", "\n")
+	normalized = strings.ReplaceAll(normalized, "\r", "\n")
+	return strings.Split(normalized, "\n")
+}

--- a/pkg/patch/patch_test.go
+++ b/pkg/patch/patch_test.go
@@ -1,0 +1,69 @@
+package patch
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestApplyToMemoryUpdatesDocument(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	patchBody := strings.Join([]string{
+		"*** Begin Patch",
+		"*** Update File: notes.txt",
+		"@@",
+		"-alpha",
+		"+gamma",
+		"*** End Patch",
+	}, "\n")
+
+	initial := map[string]string{"notes.txt": "alpha\nbeta\n"}
+	updated, results, err := ApplyMemoryPatch(ctx, patchBody, initial, Options{IgnoreWhitespace: true})
+	if err != nil {
+		t.Fatalf("ApplyMemoryPatch returned error: %v", err)
+	}
+	if got, want := len(results), 1; got != want {
+		t.Fatalf("unexpected result count: got %d want %d", got, want)
+	}
+	if results[0].Status != "M" || results[0].Path != "notes.txt" {
+		t.Fatalf("unexpected result entry: %+v", results[0])
+	}
+	if got, want := updated["notes.txt"], "gamma\nbeta\n"; got != want {
+		t.Fatalf("updated document mismatch: got %q want %q", got, want)
+	}
+
+	// Ensure the original map was not mutated.
+	if got, want := initial["notes.txt"], "alpha\nbeta\n"; got != want {
+		t.Fatalf("initial map mutated: got %q want %q", got, want)
+	}
+}
+
+func TestApplyToMemoryAddsDocument(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	patchBody := strings.Join([]string{
+		"*** Begin Patch",
+		"*** Add File: new.txt",
+		"@@",
+		"+hello",
+		"+world",
+		"*** End Patch",
+	}, "\n")
+
+	updated, results, err := ApplyMemoryPatch(ctx, patchBody, map[string]string{}, Options{})
+	if err != nil {
+		t.Fatalf("ApplyMemoryPatch returned error: %v", err)
+	}
+	if _, ok := updated["new.txt"]; !ok {
+		t.Fatalf("expected new file to exist")
+	}
+	if got, want := updated["new.txt"], "hello\nworld"; got != want {
+		t.Fatalf("new file content mismatch: got %q want %q", got, want)
+	}
+	if len(results) != 1 || results[0].Status != "A" {
+		t.Fatalf("unexpected results: %+v", results)
+	}
+}


### PR DESCRIPTION
## Summary
- extract the apply_patch parser and runtime logic into a reusable `pkg/patch` library with filesystem and in-memory backends
- update the internal apply_patch command to consume the new package and simplify its implementation
- document the new package and add unit tests that cover string-based patch application

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68fe0c6bb1888328b99964a4a6a28975