### PR TITLE
test: expand coverage for patch library

### DIFF
--- a/pkg/patch/apply_hunk_test.go
+++ b/pkg/patch/apply_hunk_test.go
@@ -1,0 +1,72 @@
+package patch
+
+import "testing"
+
+func TestApplyHunkInsertsAtEnd(t *testing.T) {
+	t.Parallel()
+
+	st := &state{
+		lines:   []string{"alpha", ""},
+		options: Options{},
+	}
+	hunk := Hunk{After: []string{"beta"}}
+
+	if err := applyHunk(st, hunk); err != nil {
+		t.Fatalf("applyHunk returned error: %v", err)
+	}
+	if len(st.lines) < 2 || st.lines[1] != "beta" {
+		t.Fatalf("unexpected lines: %#v", st.lines)
+	}
+	if st.cursor != 2 {
+		t.Fatalf("cursor not updated, got %d", st.cursor)
+	}
+}
+
+func TestApplyHunkMatchesWithWhitespaceNormalization(t *testing.T) {
+	t.Parallel()
+
+	st := &state{
+		relativePath: "example.txt",
+		lines:        []string{"value    one", "next"},
+		options:      Options{IgnoreWhitespace: true},
+	}
+	hunk := Hunk{Before: []string{"valueone"}, After: []string{"value two"}}
+
+	if err := applyHunk(st, hunk); err != nil {
+		t.Fatalf("applyHunk returned error: %v", err)
+	}
+	if st.lines[0] != "value two" {
+		t.Fatalf("line not replaced: %#v", st.lines)
+	}
+}
+
+func TestApplyHunkReturnsDetailedErrorWhenMissing(t *testing.T) {
+	t.Parallel()
+
+	st := &state{
+		relativePath: "missing.txt",
+		lines:        []string{"first"},
+		options:      Options{},
+	}
+	hunk := Hunk{Before: []string{"other"}, After: []string{"new"}}
+
+	err := applyHunk(st, hunk)
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	perr, ok := err.(*Error)
+	if !ok {
+		t.Fatalf("expected *Error, got %T", err)
+	}
+	if perr.OriginalContent == "" {
+		t.Fatalf("expected original content to be included")
+	}
+}
+
+func TestSplice(t *testing.T) {
+	t.Parallel()
+
+	if got := splice([]string{"a", "b", "c"}, 1, 1, []string{"x", "y"}); len(got) != 4 || got[1] != "x" || got[2] != "y" {
+		t.Fatalf("unexpected splice result: %#v", got)
+	}
+}

--- a/pkg/patch/apply_internal_test.go
+++ b/pkg/patch/apply_internal_test.go
@@ -1,0 +1,205 @@
+package patch
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+type stubWorkspace struct {
+	ensureFunc func(path string, create bool) (*state, error)
+	deleteFunc func(path string) error
+	commitFunc func() ([]Result, error)
+}
+
+func (s *stubWorkspace) Ensure(path string, create bool) (*state, error) {
+	if s.ensureFunc != nil {
+		return s.ensureFunc(path, create)
+	}
+	return nil, errors.New("unexpected Ensure call")
+}
+
+func (s *stubWorkspace) Delete(path string) error {
+	if s.deleteFunc != nil {
+		return s.deleteFunc(path)
+	}
+	return errors.New("unexpected Delete call")
+}
+
+func (s *stubWorkspace) Commit() ([]Result, error) {
+	if s.commitFunc != nil {
+		return s.commitFunc()
+	}
+	return nil, errors.New("unexpected Commit call")
+}
+
+func TestApplyReturnsErrorForNilWorkspace(t *testing.T) {
+	t.Parallel()
+
+	_, err := apply(context.Background(), nil, nil)
+	if err == nil {
+		t.Fatalf("expected error when workspace is nil")
+	}
+}
+
+func TestApplyHonorsContextCancellation(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	ws := &stubWorkspace{}
+	operations := []Operation{{Type: OperationDelete, Path: "file.txt"}}
+
+	_, err := apply(ctx, operations, ws)
+	if err == nil {
+		t.Fatalf("expected cancellation error")
+	}
+	var pe *Error
+	if !errors.As(err, &pe) {
+		t.Fatalf("expected *Error, got %T", err)
+	}
+	if !strings.Contains(pe.Message, "context canceled") {
+		t.Fatalf("unexpected message: %q", pe.Message)
+	}
+}
+
+func TestApplyWrapsWorkspaceErrors(t *testing.T) {
+	t.Parallel()
+
+	ws := &stubWorkspace{
+		deleteFunc: func(string) error {
+			return fmt.Errorf("boom")
+		},
+	}
+
+	operations := []Operation{{Type: OperationDelete, Path: "ghost.txt"}}
+	_, err := apply(context.Background(), operations, ws)
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	var pe *Error
+	if !errors.As(err, &pe) {
+		t.Fatalf("expected *Error, got %T", err)
+	}
+	if pe.Message != "boom" {
+		t.Fatalf("unexpected error message: %q", pe.Message)
+	}
+}
+
+func TestApplyEnhancesFailedHunk(t *testing.T) {
+	t.Parallel()
+
+	st := &state{
+		path:         "/tmp/project/example.txt",
+		relativePath: "example.txt",
+		lines:        []string{"alpha", "beta"},
+		options:      Options{},
+	}
+
+	ws := &stubWorkspace{
+		ensureFunc: func(path string, create bool) (*state, error) {
+			if path != "example.txt" || create {
+				t.Fatalf("unexpected Ensure args: %q create=%v", path, create)
+			}
+			return st, nil
+		},
+		commitFunc: func() ([]Result, error) {
+			t.Fatalf("commit should not be reached on failure")
+			return nil, nil
+		},
+	}
+
+	operations := []Operation{{
+		Type: OperationUpdate,
+		Path: "example.txt",
+		Hunks: []Hunk{{
+			Header: "@@",
+			Before: []string{"missing"},
+			After:  []string{"replacement"},
+			RawPatchLines: []string{
+				"@@",
+				"-missing",
+				"+replacement",
+			},
+		}},
+	}}
+
+	_, err := apply(context.Background(), operations, ws)
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	var pe *Error
+	if !errors.As(err, &pe) {
+		t.Fatalf("expected *Error, got %T", err)
+	}
+	if pe.Code != "HUNK_NOT_FOUND" {
+		t.Fatalf("expected HUNK_NOT_FOUND, got %q", pe.Code)
+	}
+	if pe.RelativePath != "example.txt" {
+		t.Fatalf("unexpected relative path: %q", pe.RelativePath)
+	}
+	if len(pe.HunkStatuses) != 1 || pe.HunkStatuses[0].Status != "no-match" {
+		t.Fatalf("unexpected hunk statuses: %#v", pe.HunkStatuses)
+	}
+	if pe.FailedHunk == nil || len(pe.FailedHunk.RawPatchLines) == 0 {
+		t.Fatalf("expected failed hunk details: %#v", pe.FailedHunk)
+	}
+}
+
+func TestApplyTrimsMovePathAndCommits(t *testing.T) {
+	t.Parallel()
+
+	st := &state{
+		path:         "/tmp/work/original.txt",
+		relativePath: "original.txt",
+		lines:        []string{"alpha"},
+		options:      Options{},
+	}
+
+	committed := false
+	ws := &stubWorkspace{
+		ensureFunc: func(path string, create bool) (*state, error) {
+			if path != "original.txt" {
+				t.Fatalf("unexpected path: %q", path)
+			}
+			return st, nil
+		},
+		commitFunc: func() ([]Result, error) {
+			committed = true
+			if st.movePath != "moved.txt" {
+				t.Fatalf("move path not trimmed: %q", st.movePath)
+			}
+			if got, want := st.lines, []string{"beta"}; len(got) != len(want) || got[0] != want[0] {
+				t.Fatalf("unexpected lines: %#v", st.lines)
+			}
+			if !st.touched {
+				t.Fatalf("state should be marked as touched")
+			}
+			return []Result{{Status: "M", Path: "moved.txt"}}, nil
+		},
+	}
+
+	operations := []Operation{{
+		Type:     OperationUpdate,
+		Path:     "original.txt",
+		MovePath: "  moved.txt  ",
+		Hunks: []Hunk{{
+			Before: []string{"alpha"},
+			After:  []string{"beta"},
+		}},
+	}}
+
+	results, err := apply(context.Background(), operations, ws)
+	if err != nil {
+		t.Fatalf("apply returned error: %v", err)
+	}
+	if !committed {
+		t.Fatalf("commit was not called")
+	}
+	if len(results) != 1 || results[0].Path != "moved.txt" {
+		t.Fatalf("unexpected results: %#v", results)
+	}
+}

--- a/pkg/patch/filesystem_test.go
+++ b/pkg/patch/filesystem_test.go
@@ -1,0 +1,76 @@
+package patch
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestApplyFilesystemUpdatesFile(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "foo.txt"), []byte("one\n"), 0o644); err != nil {
+		t.Fatalf("failed to write fixture: %v", err)
+	}
+
+	ops := []Operation{{
+		Type:  OperationUpdate,
+		Path:  "foo.txt",
+		Hunks: []Hunk{{Before: []string{"one"}, After: []string{"two"}}},
+	}}
+
+	results, err := ApplyFilesystem(context.Background(), ops, FilesystemOptions{WorkingDir: dir})
+	if err != nil {
+		t.Fatalf("ApplyFilesystem returned error: %v", err)
+	}
+	if len(results) != 1 || results[0].Status != "M" {
+		t.Fatalf("unexpected results: %#v", results)
+	}
+	content, err := os.ReadFile(filepath.Join(dir, "foo.txt"))
+	if err != nil {
+		t.Fatalf("failed to read file: %v", err)
+	}
+	if string(content) != "two\n" {
+		t.Fatalf("unexpected content: %q", content)
+	}
+}
+
+func TestApplyFilesystemAddsAndMovesFile(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	ops := []Operation{{
+		Type:  OperationAdd,
+		Path:  "new.txt",
+		Hunks: []Hunk{{After: []string{"hello"}}},
+	}, {
+		Type:     OperationUpdate,
+		Path:     "new.txt",
+		MovePath: "nested/moved.txt",
+		Hunks: []Hunk{{
+			Before: []string{"hello"},
+			After:  []string{"world"},
+		}},
+	}}
+
+	results, err := ApplyFilesystem(context.Background(), ops, FilesystemOptions{WorkingDir: dir})
+	if err != nil {
+		t.Fatalf("ApplyFilesystem returned error: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("unexpected results: %#v", results)
+	}
+	if results[0].Status != "A" || results[0].Path != "nested/moved.txt" {
+		t.Fatalf("unexpected result entry: %#v", results[0])
+	}
+
+	content, err := os.ReadFile(filepath.Join(dir, "nested", "moved.txt"))
+	if err != nil {
+		t.Fatalf("failed to read moved file: %v", err)
+	}
+	if string(content) != "world" {
+		t.Fatalf("unexpected moved content: %q", content)
+	}
+}

--- a/pkg/patch/format_error_test.go
+++ b/pkg/patch/format_error_test.go
@@ -1,0 +1,92 @@
+package patch
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestDescribeHunkStatuses(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name     string
+		statuses []HunkStatus
+		want     string
+	}{
+		{
+			name: "empty",
+			want: "",
+		},
+		{
+			name:     "only applied",
+			statuses: []HunkStatus{{Number: 1, Status: "applied"}, {Number: 2, Status: "applied"}},
+			want:     "Hunks applied: 1, 2.",
+		},
+		{
+			name:     "mixed",
+			statuses: []HunkStatus{{Number: 1, Status: "applied"}, {Number: 3, Status: "no-match"}},
+			want:     "Hunks applied: 1.\nNo match for hunk 3.",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := describeHunkStatuses(tc.statuses); got != tc.want {
+				t.Fatalf("describeHunkStatuses() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestFormatErrorForHunkNotFound(t *testing.T) {
+	t.Parallel()
+
+	err := &Error{
+		Message:      "Hunk not found in file.",
+		Code:         "HUNK_NOT_FOUND",
+		RelativePath: "src/app.go",
+		HunkStatuses: []HunkStatus{{Number: 2, Status: "applied"}, {Number: 5, Status: "no-match"}},
+		FailedHunk: &FailedHunk{
+			Number:        5,
+			RawPatchLines: []string{"@@", "-before", "+after"},
+		},
+		OriginalContent: "line1\nline2",
+	}
+
+	got := FormatError(err)
+	if !containsAll(got, []string{
+		"Hunk not found in file.",
+		"./src/app.go",
+		"Hunks applied: 2.",
+		"No match for hunk 5.",
+		"Offending hunk:",
+		"@@",
+		"line1\nline2",
+	}) {
+		t.Fatalf("unexpected formatted output:\n%s", got)
+	}
+}
+
+func TestFormatErrorForUnknown(t *testing.T) {
+	t.Parallel()
+
+	if got := FormatError(nil); got != "Unknown error occurred." {
+		t.Fatalf("unexpected message for nil error: %q", got)
+	}
+
+	err := &Error{Message: "custom failure"}
+	if got := FormatError(err); got != "custom failure" {
+		t.Fatalf("unexpected message: %q", got)
+	}
+}
+
+func containsAll(haystack string, needles []string) bool {
+	for _, needle := range needles {
+		if !strings.Contains(haystack, needle) {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/patch/helpers_test.go
+++ b/pkg/patch/helpers_test.go
@@ -1,0 +1,72 @@
+package patch
+
+import "testing"
+
+func TestEnsureNormalizedLinesCachesResult(t *testing.T) {
+	t.Parallel()
+
+	st := &state{
+		lines:   []string{" foo ", "bar"},
+		options: Options{IgnoreWhitespace: true},
+	}
+
+	first := ensureNormalizedLines(st)
+	if first == nil || len(first) != 2 {
+		t.Fatalf("unexpected normalized lines: %#v", first)
+	}
+	if first[0] != "foo" || first[1] != "bar" {
+		t.Fatalf("unexpected normalization: %#v", first)
+	}
+
+	st.lines[0] = "baz"
+	second := ensureNormalizedLines(st)
+	if second[0] != "foo" {
+		t.Fatalf("cache should not reflect later mutations: %#v", second)
+	}
+}
+
+func TestUpdateNormalizedLinesSyncsCache(t *testing.T) {
+	t.Parallel()
+
+	st := &state{
+		lines:   []string{"alpha", "beta"},
+		options: Options{IgnoreWhitespace: true},
+	}
+	ensureNormalizedLines(st)
+
+	updateNormalizedLines(st, 1, 1, []string{"  gamma  "})
+	if got := st.normalizedLines[1]; got != "gamma" {
+		t.Fatalf("normalized line not updated, got %q", got)
+	}
+}
+
+func TestNormalizeLineDropsWhitespace(t *testing.T) {
+	t.Parallel()
+
+	if got := normalizeLine(" \t hello world \r"); got != "helloworld" {
+		t.Fatalf("normalizeLine() = %q", got)
+	}
+}
+
+func TestFindSubsequenceWithEOFRequirement(t *testing.T) {
+	t.Parallel()
+
+	haystack := []string{"a", "", ""}
+	if idx := findSubsequence(haystack, []string{""}, 0, true); idx != 1 {
+		t.Fatalf("expected match at index 1, got %d", idx)
+	}
+	if idx := findSubsequence([]string{"a", "tail"}, []string{"a"}, 0, true); idx != -1 {
+		t.Fatalf("expected no match due to EOF requirement, got %d", idx)
+	}
+}
+
+func TestMatchSatisfiesEOF(t *testing.T) {
+	t.Parallel()
+
+	if !matchSatisfiesEOF([]string{"line", ""}, 1, 1) {
+		t.Fatalf("blank tail should satisfy EOF")
+	}
+	if matchSatisfiesEOF([]string{"line", "tail"}, 0, 1) {
+		t.Fatalf("non-empty tail should fail EOF check")
+	}
+}

--- a/pkg/patch/memory_test.go
+++ b/pkg/patch/memory_test.go
@@ -1,0 +1,61 @@
+package patch
+
+import (
+	"context"
+	"testing"
+)
+
+func TestApplyToMemoryCopiesInput(t *testing.T) {
+	t.Parallel()
+
+	initial := map[string]string{"file.txt": "alpha"}
+	operations := []Operation{{
+		Type:  OperationUpdate,
+		Path:  "file.txt",
+		Hunks: []Hunk{{Before: []string{"alpha"}, After: []string{"beta"}}},
+	}}
+
+	updated, results, err := ApplyToMemory(ctxBackground(), operations, initial, Options{})
+	if err != nil {
+		t.Fatalf("ApplyToMemory returned error: %v", err)
+	}
+	if updated["file.txt"] != "beta" {
+		t.Fatalf("unexpected updated value: %q", updated["file.txt"])
+	}
+	if initial["file.txt"] != "alpha" {
+		t.Fatalf("initial map mutated: %q", initial["file.txt"])
+	}
+	if len(results) != 1 || results[0].Status != "M" {
+		t.Fatalf("unexpected results: %#v", results)
+	}
+}
+
+func TestMemoryWorkspaceDeleteMissing(t *testing.T) {
+	t.Parallel()
+
+	ws := newMemoryWorkspace(map[string]string{}, Options{})
+	if err := ws.Delete("missing.txt"); err == nil {
+		t.Fatalf("expected error when deleting missing file")
+	}
+}
+
+func TestMemoryWorkspaceCommitMoveValidatesPath(t *testing.T) {
+	t.Parallel()
+
+	ws := newMemoryWorkspace(map[string]string{"a.txt": "one"}, Options{})
+	st, err := ws.Ensure("a.txt", false)
+	if err != nil {
+		t.Fatalf("Ensure returned error: %v", err)
+	}
+	st.lines = []string{"one"}
+	st.touched = true
+	st.movePath = "."
+
+	if _, err := ws.Commit(); err == nil {
+		t.Fatalf("expected error for invalid move path")
+	}
+}
+
+func ctxBackground() context.Context {
+	return context.Background()
+}

--- a/pkg/patch/parse_additional_test.go
+++ b/pkg/patch/parse_additional_test.go
@@ -1,0 +1,37 @@
+package patch
+
+import "testing"
+
+func TestParseSupportsMoveWithoutHunks(t *testing.T) {
+	t.Parallel()
+
+	patchBody := "*** Begin Patch\n*** Update File: old.txt\n*** Move to: new.txt\n*** End Patch\n"
+	ops, err := Parse(patchBody)
+	if err != nil {
+		t.Fatalf("Parse returned error: %v", err)
+	}
+	if len(ops) != 1 {
+		t.Fatalf("expected one operation, got %d", len(ops))
+	}
+	if ops[0].MovePath != "new.txt" || ops[0].Type != OperationUpdate {
+		t.Fatalf("unexpected operation: %#v", ops[0])
+	}
+}
+
+func TestParseErrorsOnUnexpectedDiffContent(t *testing.T) {
+	t.Parallel()
+
+	patchBody := "*** Begin Patch\nnoise\n*** End Patch\n"
+	if _, err := Parse(patchBody); err == nil {
+		t.Fatalf("expected parse error for stray content")
+	}
+}
+
+func TestParseErrorsOnMissingEnd(t *testing.T) {
+	t.Parallel()
+
+	patchBody := "*** Begin Patch\n*** Add File: foo.txt\n@@\n+foo\n"
+	if _, err := Parse(patchBody); err == nil {
+		t.Fatalf("expected error for missing terminator")
+	}
+}

--- a/pkg/patch/patch_test.go
+++ b/pkg/patch/patch_test.go
@@ -67,3 +67,13 @@ func TestApplyToMemoryAddsDocument(t *testing.T) {
 		t.Fatalf("unexpected results: %+v", results)
 	}
 }
+
+func TestApplyMemoryPatchReportsParseError(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	body := "*** Begin Patch\n*** Update File: sample.txt\n*** End Patch\n"
+	if _, _, err := ApplyMemoryPatch(ctx, body, map[string]string{}, Options{}); err == nil {
+		t.Fatalf("expected parse error")
+	}
+}


### PR DESCRIPTION
## Summary
- add comprehensive unit coverage for apply workflow, helper routines, and parser edge cases in the patch library
- exercise memory and filesystem workspaces to validate map copying, move handling, and on-disk changes
- expand error formatting tests to verify structured output for end users

## Testing
- `go test ./pkg/patch -cover`


------
https://chatgpt.com/codex/tasks/task_e_68fe16d30088832889d3e284426c6a1b