### PR TITLE
Convert reasoning field to string array

### DIFF
--- a/internal/core/runtime/execution.go
+++ b/internal/core/runtime/execution.go
@@ -79,8 +79,18 @@ func (r *Runtime) recordPlanResponse(plan *PlanResponse, toolCall ToolCall) int 
 		"tool_name":           toolCall.Name,
 		"require_human_input": plan.RequireHumanInput,
 	}
-	if strings.TrimSpace(plan.Reasoning) != "" {
-		planMetadata["reasoning"] = plan.Reasoning
+	if len(plan.Reasoning) > 0 {
+		reasoning := make([]string, 0, len(plan.Reasoning))
+		for _, entry := range plan.Reasoning {
+			trimmed := strings.TrimSpace(entry)
+			if trimmed == "" {
+				continue
+			}
+			reasoning = append(reasoning, trimmed)
+		}
+		if len(reasoning) > 0 {
+			planMetadata["reasoning"] = reasoning
+		}
 	}
 
 	r.emit(RuntimeEvent{

--- a/internal/core/runtime/loop_test.go
+++ b/internal/core/runtime/loop_test.go
@@ -108,7 +108,7 @@ func TestPlanExecutionLoopPausesForHumanInput(t *testing.T) {
 
 	plan := PlanResponse{
 		Message:           "Need clarification",
-		Reasoning:         "Reviewing the prompt requires clarification.",
+		Reasoning:         []string{"Reviewing the prompt requires clarification."},
 		RequireHumanInput: true,
 		Plan: []PlanStep{{
 			ID:           "step-1",
@@ -229,7 +229,7 @@ func TestPlanExecutionLoopHandsFreeCompletes(t *testing.T) {
 
 	plan := PlanResponse{
 		Message:           "All tasks are complete.",
-		Reasoning:         "No outstanding work remains.",
+		Reasoning:         []string{"No outstanding work remains."},
 		RequireHumanInput: false,
 		Plan:              []PlanStep{},
 	}
@@ -332,7 +332,7 @@ func TestPlanExecutionLoopHandsFreeStopsAtPassLimit(t *testing.T) {
 	zero := 0
 	plan := PlanResponse{
 		Message:           "Continuing work.",
-		Reasoning:         "Execute the next command.",
+		Reasoning:         []string{"Execute the next command."},
 		RequireHumanInput: false,
 		Plan: []PlanStep{{
 			ID:           "step-1",

--- a/internal/core/runtime/types.go
+++ b/internal/core/runtime/types.go
@@ -101,7 +101,7 @@ type PlanStep struct {
 // PlanResponse captures the structured assistant output.
 type PlanResponse struct {
 	Message           string     `json:"message"`
-	Reasoning         string     `json:"reasoning,omitempty"`
+	Reasoning         []string   `json:"reasoning,omitempty"`
 	Plan              []PlanStep `json:"plan"`
 	RequireHumanInput bool       `json:"requireHumanInput"`
 }

--- a/internal/core/schema/schema.go
+++ b/internal/core/schema/schema.go
@@ -24,9 +24,10 @@ const planResponseSchemaJSON = `{
       "description": "Markdown formatted message to the user."
     },
     "reasoning": {
-      "type": "string",
+      "type": "array",
+      "items": { "type": "string" },
       "description": "Supporting reasoning or commentary that can be used to explain the plan or message without being surfaced directly to the user.",
-      "default": ""
+      "default": []
     },
     "plan": {
       "type": "array",

--- a/internal/core/schema/schema_test.go
+++ b/internal/core/schema/schema_test.go
@@ -36,7 +36,15 @@ func TestPlanResponseSchemaRequiresReasoning(t *testing.T) {
 		t.Fatalf("expected reasoning property to be defined")
 	}
 
-	if typ, _ := value["type"].(string); typ != "string" {
-		t.Fatalf("expected reasoning to be a string, got %q", typ)
+	if typ, _ := value["type"].(string); typ != "array" {
+		t.Fatalf("expected reasoning to be an array, got %q", typ)
+	}
+
+	items, ok := value["items"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected reasoning array to describe its items")
+	}
+	if itemType, _ := items["type"].(string); itemType != "string" {
+		t.Fatalf("expected reasoning items to be strings, got %q", itemType)
 	}
 }


### PR DESCRIPTION
## Summary
- update the tool schema to require `reasoning` as an array of strings
- adjust the runtime contracts and metadata handling to accept multiple reasoning lines
- refresh unit tests to cover the new schema requirements

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68fe5d4fbb888328a376a5d7c2172989